### PR TITLE
Mac support fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,14 +6,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - run: "pip3 install pygame pyinstaller pillow"
-      - run: "pyinstaller --onefile -w -n Clangen -i resources/icon.png main.py"
-      - run: "mkdir -p dist/Clangen.app/Contents/Resources/sprites/paralyzed"
-      - run: "mkdir dist/Clangen.app/Contents/Resources/saves"
-      - run: "mkdir dist/Clangen.app/Contents/Resources/resources"
-      - run: "cp -r sprites/* dist/Clangen.app/Contents/Resources/sprites"
-      - run: "cp resources/* dist/Clangen.app/Contents/Resources/resources"
-      - run: "rm dist/Clangen"
+      - run: "pip3 install -r requirements.txt"
+      - run: "pip3 install pyinstaller pillow"
+      - run: "pyinstaller Clangen.spec"
+      - run: "rm -r dist/Clangen"
       - run: "codesign --force --sign - dist/Clangen.app"
       - run: "ln -s /Applications/ dist/"
       - run: "hdiutil create Clangen.dmg -ov -volname 'Clangen' -fs HFS+ -format UDZO -srcfolder './dist/'"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+      - run: "brew install python-tk@3.10"
       - run: "pip3 install -r requirements.txt"
       - run: "pip3 install pyinstaller pillow"
       - run: "pyinstaller Clangen.spec"

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ MANIFEST
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/Clangen.spec
+++ b/Clangen.spec
@@ -1,0 +1,59 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+block_cipher = None
+
+a = Analysis(
+    ['main.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+a.datas += Tree('./resources', prefix='resources')
+a.datas += Tree('./sprites', prefix='sprites')
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='Clangen',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon='resources/icon.png',
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='Clangen',
+)
+app = BUNDLE(
+    coll,
+    name='Clangen.app',
+    icon='resources/icon.png',
+    bundle_identifier=None,
+)

--- a/main.py
+++ b/main.py
@@ -1,9 +1,9 @@
 import sys
 import os
-from scripts.screens import *
-
+from os import path
 if sys.platform == "darwin":
-    os.chdir("/Applications/Clangen.app/Contents/Resources/")
+    os.chdir(os.path.dirname(__file__))
+from scripts.screens import *
 
 # P Y G A M E
 clock = pygame.time.Clock()


### PR DESCRIPTION
Made changes so that Clangen works more robustly on MacOS.
- File path is now dynamic so Clangen can be installed in folders other than `/Applications`.
- Fixed a bug with the MacOS CI build that prevented the automatic build from launching.
- Made changes to the MacOS CI build that make launching the game much faster with the trade-off of making the filesize larger.