### PR TITLE
previous/next buttons in relationship screen

### DIFF
--- a/scripts/screens.py
+++ b/scripts/screens.py
@@ -2718,6 +2718,48 @@ class RelationshipScreen(Screens):
 
         # get the relevant cat
         the_cat = cat_class.all_cats.get(game.switches['cat'])
+        
+        # use this variable to point to the cat object in question
+        the_cat = cat_class.all_cats.get(game.switches['cat'],
+                                         game.clan.instructor)
+        # use these attributes to create differing profiles for starclan cats etc.
+        is_instructor = False
+        if the_cat.dead and game.clan.instructor.ID == the_cat.ID:
+            is_instructor = True        
+        
+        # back and next buttons on the relationships page
+        previous_cat = 0
+        next_cat = 0    
+        
+        if the_cat.dead and not is_instructor:
+            previous_cat = game.clan.instructor.ID
+        if is_instructor:
+            next_cat = 1
+        for check_cat in cat_class.all_cats:
+            if cat_class.all_cats[check_cat].ID == the_cat.ID:
+                next_cat = 1
+            if next_cat == 0 and cat_class.all_cats[
+                    check_cat].ID != the_cat.ID and cat_class.all_cats[
+                            check_cat].dead == the_cat.dead and cat_class.all_cats[
+                                check_cat].ID != game.clan.instructor.ID and not cat_class.all_cats[
+                                    check_cat].exiled:
+                previous_cat = cat_class.all_cats[check_cat].ID
+            elif next_cat == 1 and cat_class.all_cats[
+                    check_cat].ID != the_cat.ID and cat_class.all_cats[
+                            check_cat].dead == the_cat.dead and cat_class.all_cats[
+                                check_cat].ID != game.clan.instructor.ID and not cat_class.all_cats[
+                                    check_cat].exiled:
+                next_cat = cat_class.all_cats[check_cat].ID
+            elif int(next_cat) > 1:
+                break
+        if next_cat == 1:
+            next_cat = 0
+        if next_cat != 0:
+            buttons.draw_button((-40, 40), text='Next Cat', cat=next_cat, hotkey=[21])
+        if previous_cat != 0:
+            buttons.draw_button((40, 40),
+                                    text='Previous Cat',
+                                    cat=previous_cat, hotkey=[23])     
 
         # layout
 


### PR DESCRIPTION
I thought it was a bit annoying to have to go back to the profile screen of a cat just to hit the next/previous cat buttons when viewing their relationships, so I've copied the code over from profile_screen to relationship_screen so you can switch whose relationships you're viewing. The location is kinda janky and could probably go up 10ish pixels, thoughts?