### PR TITLE
Optimizing start screen, input

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,6 +46,7 @@ verdana.change_text_brightness()
 buttons.change_button_brightness()
 sprites.load_scars()
 
+pygame.event.set_allowed([pygame.KEYDOWN, pygame.QUIT, pygame.MOUSEBUTTONDOWN])
 
 while True:
     if game.settings['dark mode']:

--- a/scripts/screens.py
+++ b/scripts/screens.py
@@ -32,10 +32,13 @@ class Screens(object):
 # SCREEN CHILD CLASSES
 class StartScreen(Screens):
 
+    def __init__(self, name=None):
+        super().__init__(name)
+        self.bg = pygame.image.load("resources/menu.png").convert()
+
     def on_use(self):
         # background
-        bg = pygame.image.load("resources/menu.png").convert()
-        screen.blit(bg, (0, 0))
+        screen.blit(self.bg, (0, 0))
 
         # buttons
         if game.clan is not None and game.switches['error_message'] == '':


### PR DESCRIPTION
* Same as #99 but for the start screen.
* Only gets the map when navigating to the map screen instead of every frame.
* Limits allowed input events for pygame.