### PR TITLE
More mate fixes

### DIFF
--- a/scripts/cats.py
+++ b/scripts/cats.py
@@ -3009,6 +3009,10 @@ class Cat(object):
         if self.ID == other_cat.ID:
             return False
 
+        # check exiles and dead cats
+        if self.dead or self.exiled or other_cat.dead or other_cat.exiled:
+            return False
+
         # check for current mate
         if not for_love_interest and self.mate != None:
             return False

--- a/scripts/cats.py
+++ b/scripts/cats.py
@@ -3000,8 +3000,6 @@ class Cat(object):
             other_cat.relationships.append(
                 Relationship(other_cat, self, True))
 
-        return True
-
     def is_potential_mate(self, other_cat, for_love_interest = False):
         """Checks if this cat is a potential mate for the other cat."""
         # just to be sure, check if it is not the same cat

--- a/scripts/cats.py
+++ b/scripts/cats.py
@@ -1,4 +1,3 @@
-from msilib.schema import Error
 from .pelts import *
 from .names import *
 from .sprites import *

--- a/scripts/cats.py
+++ b/scripts/cats.py
@@ -3013,10 +3013,7 @@ class Cat(object):
             return False
 
         # check for current mate
-        if not for_love_interest and self.mate != None:
-            return False
-        
-        if for_love_interest and (self.mate != None or other_cat.mate != None):
+        if self.mate != None or other_cat.mate != None:
             if not game.settings['affair']:
                 return False
 

--- a/scripts/screens.py
+++ b/scripts/screens.py
@@ -2035,14 +2035,7 @@ class ChooseMateScreen(Screens):
     # TODO Rename this here and in `on_use`
     def _extracted_from_on_use_42(self, the_cat, valid_mates, pos_x, pos_y):
         for x in game.clan.clan_cats:
-            pos_mate = cat_class.all_cats[x]
-            if not pos_mate.dead and pos_mate.age in ['young adult', 'adult', 'senior adult', 'elder'] and the_cat != pos_mate and the_cat.ID not in [pos_mate.parent1,
-                                                                                                                                                      pos_mate.parent2] and \
-                    pos_mate.ID not in [
-                the_cat.parent1, the_cat.parent2] and pos_mate.mate is None and (pos_mate.parent1 is None or pos_mate.parent1 not in [the_cat.parent1, the_cat.parent2]) and (
-                    pos_mate.parent2 is None or pos_mate.parent2 not in [the_cat.parent1, the_cat.parent2]) and (
-                    the_cat.age in ['senior adult', 'elder'] and cat_class.all_cats[x].age in ['senior adult', 'elder'] or cat_class.all_cats[x].age != 'elder' and
-                    cat_class.all_cats[x].age != 'adolescent' and the_cat.age != 'elder' and the_cat.age != 'adolescent') and not the_cat.exiled:
+            if the_cat.is_potential_mate(cat_class.all_cats[x]):
                 valid_mates.append(cat_class.all_cats[x])
         all_pages = int(ceil(len(valid_mates) /
                              27.0)) if len(valid_mates) > 27 else 1


### PR DESCRIPTION
Should fix: 
* Mating dead cats
* Mating exiled cats
* Crash on non-Windows OS
* Constant affairs all the time

It should also make the list of mates (when manually assigning) more consistent with what kind of cats can get chosen to randomly be mated.