### PR TITLE
fix: Experience values corrupting saves

### DIFF
--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -881,6 +881,7 @@ class Patrol(object):
         elif self.patrol_event.patrol_id in [900, 901, 902]:
             for cat in self.patrol_cats:
                 cat.experience += self.patrol_event.exp
+                cat.experience = min(cat.experience, 80)
                 if cat.status == 'leader':
                     game.clan.leader_lives -= 10
                 events_class.dies(cat)


### PR DESCRIPTION
Fixes an issue where certain events would make experience values would go over 80 and break a cat's save.