### PR TITLE
Bugfix: resources not found and countdown init to 0

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,8 @@
 import sys
 import os
-from os import path
-if sys.platform == "darwin":
-    directory = os.path.dirname(__file__)
-    if directory:
-        os.chdir(directory)
+directory = os.path.dirname(__file__)
+if directory:
+    os.chdir(directory)
 from scripts.screens import *
 
 # P Y G A M E

--- a/scripts/cats.py
+++ b/scripts/cats.py
@@ -376,7 +376,7 @@ class Cat(object):
             while other_cat == c:
                 other_cat = random.choice(list(self.all_cats.keys()))
                 countdown-=1
-                if countdown == 0:
+                if countdown <= 0:
                     continue
             other_cat = self.all_cats.get(other_cat)
             other_name = str(other_cat.name)

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -242,7 +242,7 @@ class Events(object):
         while cat == other_cat or other_cat.dead or other_cat.exiled:
             other_cat = choice(list(cat_class.all_cats.values()))
             countdown-=1
-            if countdown == 0:
+            if countdown <= 0:
                 return
         other_name = str(other_cat.name)
         acc_text = []
@@ -317,7 +317,7 @@ class Events(object):
         while cat == other_cat or other_cat.dead or other_cat.exiled:
             other_cat = choice(list(cat_class.all_cats.values()))
             countdown-=1
-            if countdown == 0:
+            if countdown <= 0:
                 return
         other_name = str(other_cat.name)
         scar_text = []
@@ -852,7 +852,7 @@ class Events(object):
         while cat == other_cat or other_cat.dead or other_cat.exiled:
             other_cat = choice(list(cat_class.all_cats.values()))
             countdown-=1
-            if countdown == 0:
+            if countdown <= 0:
                 return
         name = str(cat.name)
         other_name = str(other_cat.name)
@@ -941,7 +941,7 @@ class Events(object):
             while cat == other_cat or other_cat.dead or other_cat.status == 'leader' or other_cat.exiled:
                 other_cat = choice(list(cat_class.all_cats.values()))
                 countdown-=1
-                if countdown == 0:
+                if countdown <= 0:
                     return
             if cat.status == 'leader':
                 other_name = str(other_cat.name)
@@ -1239,7 +1239,7 @@ class Events(object):
             while cat == other_cat or other_cat.dead or other_cat.exiled:
                 other_cat = choice(list(cat_class.all_cats.values()))
                 countdown-=1
-                if countdown == 0:
+                if countdown <= 0:
                     return
             other_name = str(other_cat.name)
             cause_of_death = [
@@ -1280,7 +1280,7 @@ class Events(object):
             while cat == other_cat or other_cat.dead or other_cat.exiled:
                 other_cat = choice(list(cat_class.all_cats.values()))
                 countdown-=1
-                if countdown == 0:
+                if countdown <= 0:
                     return
             other_name = str(other_cat.name)
             if cat.trait in [


### PR DESCRIPTION
The fix for resources not found was already in place, but for Mac only. I took out the Mac-only if, which I think should be fine (it fixed it for me on Windows).

The other fix isn't a bug I've actually seen, but if somehow the number of cats was 2 or less, the countdowns would be initialized to 0 and then get stuck in the while loop. So check if it's <=0 instead of ==0.