### PR TITLE
other: Auto save less often

### DIFF
--- a/scripts/buttons.py
+++ b/scripts/buttons.py
@@ -369,7 +369,6 @@ class Button(object):
             apprentice.mentor = cat_value
             cat_value.apprentice.append(apprentice)
         game.current_screen = 'clan screen'
-        cat_class.json_save_cats()
 
     def change_name(self, name, cat_value):
         """Changes name of cat_value to name specified in textbox"""
@@ -382,14 +381,12 @@ class Button(object):
                 if not (cat_value.name.status == "apprentice" and name[1] == "paw") and \
                     not (cat_value.name.status == "kitten" and name[1] == "kit"):
                     cat_value.name.suffix = name[1]
-            cat_class.json_save_cats()
             game.switches['naming_text'] = ''
 
     def change_gender(self, name, cat_value):
         cat_value = cat_class.all_cats.get(cat_value)
         if game.switches['naming_text'] != '':
             cat_value.genderalign = game.switches['naming_text']
-            cat_class.json_save_cats()
             game.switches['naming_text'] = ''
 
 


### PR DESCRIPTION
Cats were automatically saving when changing name, changing gender, and choosing apprentices. This caused lag because saving is slow. This PR removes this auto saving. 

The game probably shouldn't be saved in these places anyway because it's unintuitive for users.