### PR TITLE
Fix: Various moon skip crashes

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -926,7 +926,8 @@ class Events(object):
                 f'{name} tries to convince {other_name} to run away together'
             ])
 
-        game.cur_events_list.append(choice(interactions))
+        if interactions:
+            game.cur_events_list.append(choice(interactions))
 
     def handle_deaths(self, cat):
         clan_has_kits = any(

--- a/scripts/relation_events.py
+++ b/scripts/relation_events.py
@@ -4,6 +4,9 @@ from .utility import *
 
 class Relation_Events(object):
     """All relationship events."""
+
+    MAX_ATTEMPTS = 1000
+
     def __init__(self) -> None:
         self.living_cats = len(list(filter(lambda r: r.dead == False, cat_class.all_cats.copy().values())))
         self.event_sums = 0
@@ -62,7 +65,8 @@ class Relation_Events(object):
                 not relation.cat_to.dead, cat.relationships))
         random_cat = cat.all_cats.get(random_id)
         kitten_and_exiled = random_cat.exiled and cat.age == "kitten"
-        while len(relevant_relationship_list) < 1 or random_id == cat.ID or kitten_and_exiled:
+        attempts = 0
+        while (len(relevant_relationship_list) < 1 or random_id == cat.ID or kitten_and_exiled) and attempts < Relation_Events.MAX_ATTEMPTS:
             random_id = random.choice(list(cat.all_cats.keys()))
             random_cat = cat.all_cats.get(random_id)
             kitten_and_exiled = random_cat.exiled and cat.age == "kitten"
@@ -70,8 +74,10 @@ class Relation_Events(object):
                 filter(
                     lambda relation: str(relation.cat_to) == str(random_id) and
                     not relation.cat_to.dead, cat.relationships))
-        relevant_relationship = relevant_relationship_list[0]
-        relevant_relationship.start_action()
+            attempts += 1
+        if len(relevant_relationship_list) >= 1:
+            relevant_relationship = relevant_relationship_list[0]
+            relevant_relationship.start_action()
 
     def handle_relationships(self, cat):
         """Iterate over all relationships and trigger different events."""

--- a/scripts/relation_events.py
+++ b/scripts/relation_events.py
@@ -65,8 +65,8 @@ class Relation_Events(object):
                 not relation.cat_to.dead, cat.relationships))
         random_cat = cat.all_cats.get(random_id)
         kitten_and_exiled = random_cat.exiled and cat.age == "kitten"
-        attempts = 0
-        while (len(relevant_relationship_list) < 1 or random_id == cat.ID or kitten_and_exiled) and attempts < Relation_Events.MAX_ATTEMPTS:
+        attempts_left = Relation_Events.MAX_ATTEMPTS
+        while len(relevant_relationship_list) < 1 or random_id == cat.ID or kitten_and_exiled:
             random_id = random.choice(list(cat.all_cats.keys()))
             random_cat = cat.all_cats.get(random_id)
             kitten_and_exiled = random_cat.exiled and cat.age == "kitten"
@@ -74,10 +74,11 @@ class Relation_Events(object):
                 filter(
                     lambda relation: str(relation.cat_to) == str(random_id) and
                     not relation.cat_to.dead, cat.relationships))
-            attempts += 1
-        if len(relevant_relationship_list) >= 1:
-            relevant_relationship = relevant_relationship_list[0]
-            relevant_relationship.start_action()
+            attempts_left -= 1
+            if attempts_left <= 0:
+                return
+        relevant_relationship = relevant_relationship_list[0]
+        relevant_relationship.start_action()
 
     def handle_relationships(self, cat):
         """Iterate over all relationships and trigger different events."""

--- a/scripts/screens.py
+++ b/scripts/screens.py
@@ -1504,7 +1504,6 @@ class EventsScreen(Screens):
         if game.cur_events_list is not None and game.cur_events_list != []:
             for x in range(
                     min(len(game.cur_events_list), game.max_events_displayed)):
-                if game.cur_events_list[x] is None:
                 #TODO: Find the real cause for game.cur_events_list[x] being a function sometimes
                 if game.cur_events_list[x] is None or not isinstance(game.cur_events_list[x], str):
                     continue

--- a/scripts/screens.py
+++ b/scripts/screens.py
@@ -1505,6 +1505,8 @@ class EventsScreen(Screens):
             for x in range(
                     min(len(game.cur_events_list), game.max_events_displayed)):
                 if game.cur_events_list[x] is None:
+                #TODO: Find the real cause for game.cur_events_list[x] being a function sometimes
+                if game.cur_events_list[x] is None or not isinstance(game.cur_events_list[x], str):
                     continue
                 if "Clan has no " in game.cur_events_list[x]:
                     verdana_red.text(game.cur_events_list[x],


### PR DESCRIPTION
Fixes some crashes relating to moon skips. More specifically: 
* `TypeError: builtin_function_or_method object is not iterable` - Root cause still not found, but this should prevent the crash. Hopefully. 
* Occasional infinite loading on moonskip 
* Crash when a cat in an interaction event can't find anybody else to interact with.