### PR TITLE
fix: Cats missing relationships

### DIFF
--- a/scripts/cats.py
+++ b/scripts/cats.py
@@ -2899,6 +2899,8 @@ class Cat(object):
                     self.relationships = relationships
             except:
                 print(f'There was an error reading the relationship file of cat #{self}.')
+        else:
+            self.create_new_relationships()
 
     def load(self, cat_dict):
         """ A function that takes a dictionary containing other dictionaries with attributes and values of all(?)


### PR DESCRIPTION
Cats missing relationship files (e.g. custom cats, cats imported through the save converter) wouldn't have any relationships at all. This gives them a relationship with the clan if there's no relationship file to read.