### PR TITLE
Bugfix: Kit traits being assigned to older cats

### DIFF
--- a/scripts/cats.py
+++ b/scripts/cats.py
@@ -2418,11 +2418,11 @@ class Cat(object):
                     if self.trait in self.personality_groups[x]:
                         possible_trait = self.personality_groups.get(x)
                         chosen_trait = choice(possible_trait)
-                        if chosen_trait not in self.kit_traits:
-                            self.trait = chosen_trait
-                            print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
-                        else:
-                            continue
+                        for y in self.kit_traits:
+                            if chosen_trait != y:
+                                print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
+                                break
+
         if self.moons == 12:
             chance = randint(0, 5)  # chance for cat to gain new trait or keep old
             if chance == 0:
@@ -2434,11 +2434,10 @@ class Cat(object):
                     if self.trait in self.personality_groups[x]:
                         possible_trait = self.personality_groups.get(x)
                         chosen_trait = choice(possible_trait)
-                        if chosen_trait not in self.kit_traits:
-                            self.trait = chosen_trait
-                            print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
-                        else:
-                            continue
+                        for y in self.kit_traits:
+                            if chosen_trait != y:
+                                print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
+                                break
             else:
                 print(self.name, 'NEW TRAIT TYPE: No change', chance)
         if new_status == 'elder':
@@ -2452,11 +2451,10 @@ class Cat(object):
                     if self.trait in self.personality_groups[x]:
                         possible_trait = self.personality_groups.get(x)
                         chosen_trait = choice(possible_trait)
-                        if chosen_trait not in self.kit_traits:
-                            self.trait = chosen_trait
-                            print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
-                        else:
-                            continue
+                        for y in self.kit_traits:
+                            if chosen_trait != y:
+                                print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
+                                break
 
             else:
                 print(self.name, 'NEW TRAIT TYPE: No change', chance)

--- a/scripts/cats.py
+++ b/scripts/cats.py
@@ -2421,6 +2421,8 @@ class Cat(object):
                         if chosen_trait not in self.kit_traits:
                             self.trait = chosen_trait
                             print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
+                        else:
+                            continue
         if self.moons == 12:
             chance = randint(0, 5)  # chance for cat to gain new trait or keep old
             if chance == 0:
@@ -2433,9 +2435,10 @@ class Cat(object):
                         possible_trait = self.personality_groups.get(x)
                         chosen_trait = choice(possible_trait)
                         if chosen_trait not in self.kit_traits:
-                            if chosen_trait != self.trait:
-                                self.trait = chosen_trait
-                                print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
+                            self.trait = chosen_trait
+                            print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
+                        else:
+                            continue
             else:
                 print(self.name, 'NEW TRAIT TYPE: No change', chance)
         if self.moons == 120:
@@ -2450,9 +2453,10 @@ class Cat(object):
                         possible_trait = self.personality_groups.get(x)
                         chosen_trait = choice(possible_trait)
                         if chosen_trait not in self.kit_traits:
-                            if chosen_trait != self.trait:
-                                self.trait = chosen_trait
-                                print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
+                            self.trait = chosen_trait
+                            print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
+                        else:
+                            continue
 
             else:
                 print(self.name, 'NEW TRAIT TYPE: No change', chance)

--- a/scripts/cats.py
+++ b/scripts/cats.py
@@ -2441,7 +2441,7 @@ class Cat(object):
                             continue
             else:
                 print(self.name, 'NEW TRAIT TYPE: No change', chance)
-        if self.moons == 120:
+        if new_status == 'elder':
             chance = randint(0, 7)  # chance for cat to gain new trait or keep old
             if chance == 0:
                 self.trait = choice(self.traits)
@@ -2476,7 +2476,7 @@ class Cat(object):
         else:
             self.skill = self.skill
 
-        if self.moons >= 120 and self.status != 'leader' and self.status != 'medicine cat':
+        if new_status == 'elder' and self.status != 'leader' and self.status != 'medicine cat':
             self.skill = choice(self.elder_skills)
 
         self.status = new_status

--- a/scripts/cats.py
+++ b/scripts/cats.py
@@ -2411,39 +2411,51 @@ class Cat(object):
             chance = randint(0, 5)  # chance for cat to gain trait that matches their previous trait's personality group
             if chance == 0:
                 self.trait = choice(self.traits)
-                print('TRAIT TYPE: Random - CHANCE', chance)
+                print(self.name, 'NEW TRAIT TYPE: Random - CHANCE', chance)
             else:
                 possible_groups = ['Outgoing', 'Benevolent', 'Abrasive', 'Reserved']
                 for x in possible_groups:
                     if self.trait in self.personality_groups[x]:
                         possible_trait = self.personality_groups.get(x)
-                        self.trait = choice(possible_trait)
-                        print('TRAIT TYPE:', x, 'CHANCE:', chance)
+                        chosen_trait = choice(possible_trait)
+                        if chosen_trait not in self.kit_traits:
+                            self.trait = chosen_trait
+                            print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
         if self.moons == 12:
             chance = randint(0, 5)  # chance for cat to gain new trait or keep old
             if chance == 0:
-                possible_groups = ['Outgoing', 'Benevolent', 'Abrasive', 'Reserved']
-                for x in possible_groups:
-                    if self.trait in self.personality_groups[x]:
-                        possible_trait = self.personality_groups.get(x)
-                        self.trait = choice(possible_trait)
-                        print('TRAIT TYPE:', x, 'CHANCE:', chance)
-            else:
-                print('TRAIT TYPE: No change', chance)
-        if self.moons == 120:
-            chance = randint(0, 5)  # chance for cat to gain new trait or keep old
-            if chance == 0:
-                possible_groups = ['Outgoing', 'Benevolent', 'Abrasive', 'Reserved']
-                for x in possible_groups:
-                    if self.trait in self.personality_groups[x]:
-                        possible_trait = self.personality_groups.get(x)
-                        self.trait = choice(possible_trait)
-                        print('TRAIT TYPE:', x, 'CHANCE:', chance)
-            elif chance == 1:
                 self.trait = choice(self.traits)
-                print('TRAIT TYPE: Random - CHANCE', chance)
+                print(self.name, 'NEW TRAIT TYPE: Random - CHANCE', chance)
+            elif chance == 1 or chance == 2:
+                possible_groups = ['Outgoing', 'Benevolent', 'Abrasive', 'Reserved']
+                for x in possible_groups:
+                    if self.trait in self.personality_groups[x]:
+                        possible_trait = self.personality_groups.get(x)
+                        chosen_trait = choice(possible_trait)
+                        if chosen_trait not in self.kit_traits:
+                            if chosen_trait != self.trait:
+                                self.trait = chosen_trait
+                                print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
             else:
-                print('TRAIT TYPE: No change', chance)
+                print(self.name, 'NEW TRAIT TYPE: No change', chance)
+        if self.moons == 120:
+            chance = randint(0, 7)  # chance for cat to gain new trait or keep old
+            if chance == 0:
+                self.trait = choice(self.traits)
+                print(self.name, 'NEW TRAIT TYPE: Random - CHANCE', chance)
+            elif chance == 1:
+                possible_groups = ['Outgoing', 'Benevolent', 'Abrasive', 'Reserved']
+                for x in possible_groups:
+                    if self.trait in self.personality_groups[x]:
+                        possible_trait = self.personality_groups.get(x)
+                        chosen_trait = choice(possible_trait)
+                        if chosen_trait not in self.kit_traits:
+                            if chosen_trait != self.trait:
+                                self.trait = chosen_trait
+                                print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
+
+            else:
+                print(self.name, 'NEW TRAIT TYPE: No change', chance)
         # updates mentors
         if new_status == 'apprentice':
             self.update_mentor()


### PR DESCRIPTION
Added a check for cat trait switching to ensure that they wouldn't switch to a kit trait.  
Also adjusted the elder skill change to change skills when the cat retires rather than when they reach 120 moons.

--Don't merge!  Lixxis will be adding these changes to their reorganizing of cat.py rather than merging it now.