### PR TITLE
Bugfixes: Trait Switching - Missing patrols - Typos

### DIFF
--- a/resources/dicts/patrols/general.json
+++ b/resources/dicts/patrols/general.json
@@ -1,7 +1,7 @@
 [
     {
         "patrol_id": 100,
-        "intro_text": "Your patrol doesn't find anything useful'",
+        "intro_text": "Your patrol doesn't find anything useful",
         "success_text": "It was still a fun outing!",
         "fail_text": "How did you fail this??",
         "decline_text": "Your patrol decides to head home early",
@@ -13,7 +13,7 @@
     },
     {
         "patrol_id": 101,
-        "intro_text": "The patrol finds a nice spot to sun themselve",
+        "intro_text": "The patrol finds a nice spot to sun themselves",
         "success_text": "The sunlight feels great and they have a pleasant patrol",
         "fail_text": "The patrol doesn't get much done because of that",
         "decline_text": "They decide to stay focused instead",

--- a/resources/dicts/patrols/general_new_cat.json
+++ b/resources/dicts/patrols/general_new_cat.json
@@ -46,5 +46,17 @@
         "chance_of_success": 40,
         "exp": 10,
         "win_skills": ["smart", "very smart", "extremely smart"]
+    },
+    {
+        "patrol_id": 505,
+        "intro_text": "r_c finds a loner who offers their healing skills in exchange for shelter",
+        "success_text": "The new medicine cat is welcomed into the clan",
+        "fail_text": "After hearing more about your clan, the loner decides not to join",
+        "decline_text": "The patrol declines their offer",
+        "antagonize_text": "Your patrol drives the cat off of the territory",
+        "antagonize_fail_text": "The loner is taken aback by their hostility and decides this clan is not for them",
+        "chance_of_success": 40,
+        "exp": 10,
+        "win_skills": ["great speaker", "excellent speaker"]
     }
 ]

--- a/resources/dicts/patrols/general_new_cat.json
+++ b/resources/dicts/patrols/general_new_cat.json
@@ -48,6 +48,18 @@
         "win_skills": ["smart", "very smart", "extremely smart"]
     },
     {
+        "patrol_id": 504,
+        "intro_text": "r_c finds an abandoned kit whose mother is nowhere to be found",
+        "success_text": "The kit is taken back to camp and nursed back to health",
+        "fail_text": "The kit is taken back to camp, but grows weak and dies a few days later",
+        "decline_text": "They leave the kit alone",
+        "antagonize_text": "Your patrol moves the kit away from the territory, they have no interest in strange kits",
+        "antagonize_fail_text": "The kit smells of two-legs, your patrol has no interest in what will surely grow to be a weak cat",
+        "chance_of_success": 40,
+        "exp": 10,
+        "win_skills": ["smart", "very smart", "extremely smart"]
+    },
+    {
         "patrol_id": 505,
         "intro_text": "r_c finds a loner who offers their healing skills in exchange for shelter",
         "success_text": "The new medicine cat is welcomed into the clan",

--- a/resources/dicts/patrols/leaves/greenleaf.json
+++ b/resources/dicts/patrols/leaves/greenleaf.json
@@ -4,7 +4,7 @@
         "intro_text": "It is extremely hot out today; r_c debates turning back home",
         "success_text": "They decide to power through the weather and the patrol is successful",
         "fail_text": "r_c collapses from heat exhaustion",
-        "decline_text": "",
+        "decline_text": "The patrol decides to head back to camp, they can patrol a different day",
         "antagonize_text": "",
         "antagonize_fail_text": "",
         "chance_of_success": 50,

--- a/resources/dicts/patrols/leaves/leaf-fall.json
+++ b/resources/dicts/patrols/leaves/leaf-fall.json
@@ -1,7 +1,7 @@
 [
     {
         "patrol_id": 130,
-        "intro_text": "The leaves are starting to turn colors; the patrol know leaf-bare will be here soon",
+        "intro_text": "The leaves are starting to turn colors; the patrol knows leaf-bare will be here soon",
         "success_text": "For now, hunting is still good",
         "fail_text": "A chilly wind makes it difficult to hunt",
         "decline_text": "The patrol is uneventful",

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -300,7 +300,7 @@ class Cat(object):
         self.all_cats[self.ID] = self
 
     def update_traits(self, new_status):
-        if self.moons == 6:
+        if new_status == 'apprentice' or new_status == 'medicine cat apprentice':
             chance = randint(0, 5)  # chance for cat to gain trait that matches their previous trait's personality group
             if chance == 0:
                 self.trait = choice(self.traits)
@@ -311,11 +311,14 @@ class Cat(object):
                     if self.trait in self.personality_groups[x]:
                         possible_trait = self.personality_groups.get(x)
                         chosen_trait = choice(possible_trait)
-                        for y in self.kit_traits:
-                            if chosen_trait != y:
-                                print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
-                                break
-        if self.moons == 12:
+                        if chosen_trait in self.kit_traits:
+                            self.trait = choice(self.traits)
+                            print(self.name, 'trait type chosen was kit trait -', self.trait,
+                                  'chosen randomly instead')
+                        else:
+                            self.trait = chosen_trait
+                            print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
+        if new_status == 'warrior' or new_status == 'medicine cat':
             chance = randint(0, 5)  # chance for cat to gain new trait or keep old
             if chance == 0:
                 self.trait = choice(self.traits)
@@ -326,10 +329,13 @@ class Cat(object):
                     if self.trait in self.personality_groups[x]:
                         possible_trait = self.personality_groups.get(x)
                         chosen_trait = choice(possible_trait)
-                        for y in self.kit_traits:
-                            if chosen_trait != y:
-                                print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
-                                break
+                        if chosen_trait in self.kit_traits:
+                            self.trait = choice(self.traits)
+                            print(self.name, 'trait type chosen was kit trait -', self.trait,
+                                  'chosen randomly instead')
+                        else:
+                            self.trait = chosen_trait
+                            print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
             else:
                 print(self.name, 'NEW TRAIT TYPE: No change', chance)
         if new_status == 'elder':
@@ -343,10 +349,13 @@ class Cat(object):
                     if self.trait in self.personality_groups[x]:
                         possible_trait = self.personality_groups.get(x)
                         chosen_trait = choice(possible_trait)
-                        for y in self.kit_traits:
-                            if chosen_trait != y:
-                                print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
-                                break
+                        if chosen_trait in self.kit_traits:
+                            self.trait = choice(self.traits)
+                            print(self.name, 'trait type chosen was kit trait -', self.trait,
+                                  'chosen randomly instead')
+                        else:
+                            self.trait = chosen_trait
+                            print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
             else:
                 print(self.name, 'NEW TRAIT TYPE: No change', chance)
 

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -1375,28 +1375,48 @@ class Events(object):
                     name3 = str(dead_cats[2].name)
                     name4 = str(dead_cats[3].name)
                     name5 = str(dead_cats[4].name)
-                    disaster.extend([
-                        ' drown after the camp becomes flooded',
-                        ' are killed in a battle against ' +
-                        choice(game.clan.all_clans).name + 'Clan',
-                        ' are killed after a fire rages through the camp',
-                        ' are killed in an ambush by a group of rogues',
-                        ' go missing in the night',
-                        ' are killed after a badger attack',
-                        ' die to a greencough outbreak',
-                        ' are taken away by twolegs',
-                        ' eat poisoned freshkill and die'
-                    ])
-                    if game.clan.current_season == 'Leaf-bare':
+                    if cat.status in dead_cats != 'kitten':
                         disaster.extend([
-                            ' die after freezing from a snowstorm',
-                            ' starve to death when no prey is found'
+                            ' drown after the camp becomes flooded',
+                            ' are killed in a battle against ' +
+                            choice(other_clan).name + 'Clan',
+                            ' are killed after a fire rages through the camp',
+                            ' are killed in an ambush by a group of rogues',
+                            ' go missing in the night',
+                            ' are killed after a badger attack',
+                            ' die to a greencough outbreak',
+                            ' are taken away by twolegs',
+                            ' eat poisoned freshkill and die'
                         ])
-                    elif game.clan.current_season == 'Greenleaf':
+                        if game.clan.current_season == 'Leaf-bare':
+                            disaster.extend([
+                                ' die after freezing from a snowstorm',
+                                ' starve to death when no prey is found'
+                            ])
+                        elif game.clan.current_season == 'Greenleaf':
+                            disaster.extend([
+                                ' die after overheating',
+                                ' die after the water dries up from drought'
+                            ])
+                    else:
                         disaster.extend([
-                            ' die after overheating',
-                            ' die after the water dries up from drought'
+                            ' drown after the camp becomes flooded',
+                            ' are killed after a fire rages through the camp',
+                            ' go missing in the night',
+                            ' are killed after a badger attack',
+                            ' die to a greencough outbreak',
+                            ' eat poisoned freshkill and die'
                         ])
+                        if game.clan.current_season == 'Leaf-bare':
+                            disaster.extend([
+                                ' die after freezing from a snowstorm',
+                                ' starve to death when no prey is found'
+                            ])
+                        elif game.clan.current_season == 'Greenleaf':
+                            disaster.extend([
+                                ' die after overheating',
+                                ' die after the water dries up from drought'
+                            ])
 
                     game.cur_events_list.append(name1 + ', ' + name2 + ', ' +
                                                 name3 + ', ' + name4 +

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -793,8 +793,12 @@ class Patrol(object):
                 relationships.append(Relationship(kit, the_cat))
             kit.relationships = relationships
             game.clan.add_cat(kit)
-            kit.skill = 'formerly a loner'
+            new_skill = choice(['formerly a loner', 'formerly a kittypet'])
+            kit.skill = new_skill
             kit.thought = 'Is looking around the camp with wonder'
+            if kit.skill == 'formerly a kittypet':
+                if randint(0, 2) == 0:  # chance to add collar
+                    kit.accessory = choice(collars)
 
         if self.patrol_event.patrol_id in [500, 501, 510]:  # new loner
             new_status = choice([
@@ -880,7 +884,6 @@ class Patrol(object):
             new_status = choice(['medicine cat'])
             if self.patrol_event.patrol_id == 505:
                 new_status = 'medicine cat'
-
             kit = Cat(status=new_status)
             # create and update relationships
             relationships = []

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -876,6 +876,30 @@ class Patrol(object):
                 kit.name.prefix = choice(names.loner_names)
                 kit.name.suffix = ''
 
+        elif self.patrol_event.patrol_id in [505]:  # new med cat
+            new_status = choice(['medicine cat'])
+            if self.patrol_event.patrol_id == 505:
+                new_status = 'medicine cat'
+
+            kit = Cat(status=new_status)
+            # create and update relationships
+            relationships = []
+            for cat_id in game.clan.clan_cats:
+                the_cat = cat_class.all_cats.get(cat_id)
+                if the_cat.dead or the_cat.exiled:
+                    continue
+                the_cat.relationships.append(Relationship(the_cat, kit))
+                relationships.append(Relationship(kit, the_cat))
+            kit.relationships = relationships
+            game.clan.add_cat(kit)
+            add_siblings_to_cat(kit, cat_class)
+            kit.skill = 'formerly a loner'
+            kit.thought = 'Is looking around the camp with wonder'
+            if (kit.status == 'elder'):
+                kit.moons = randint(120, 150)
+            if randint(0, 5) == 0:  # chance to keep name
+                kit.name.prefix = choice(names.loner_names)
+                kit.name.suffix = ''
     def check_territories(self):
         hunting_claim = str(game.clan.name) + 'Clan Hunting Grounds'
         self.hunting_grounds = []

--- a/scripts/screens/event_screens.py
+++ b/scripts/screens/event_screens.py
@@ -185,7 +185,7 @@ class PatrolEventScreen(Screens):
             verdana.blit_text(intro_text, (150, 200))
             buttons.draw_button((290, 320), text='Proceed', event=-2)
             buttons.draw_button((150, 320), text='Do Not Proceed', event=2)
-            if patrol.patrol_event.patrol_id in [500, 501, 502, 503, 505, 510]:
+            if patrol.patrol_event.patrol_id in [500, 501, 502, 503, 504, 505, 510]:
                 buttons.draw_button((150, 290), text='Antagonize', event=3)
 
         if game.switches['event'] == -2:


### PR DESCRIPTION
Trait Switching: cats weren't switching traits and were taking kit traits again, bug now fixed

Missing Patrols: Med cat loner and abandoned kit patrols were missing, added them back in

Mass Extinction Events: Kits no longer die in battle disaster events or other events that didn't make sense

Various typos in patrols fixed