### PR TITLE
Fix biome path not actually getting converted to lowercase.

### DIFF
--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -370,7 +370,7 @@ class ProfileScreen(Screens):
         biome = game.clan.biome
         if biome not in available_biome:
             biome = available_biome[0]
-        biome.lower()
+        biome = biome.lower()
 
         all_platforms = []
         if the_cat.dead or game.clan.instructor.ID == the_cat.ID:

--- a/scripts/screens/clan_creation_screens.py
+++ b/scripts/screens/clan_creation_screens.py
@@ -683,7 +683,7 @@ class MakeClanScreen(Screens):
         biome = game.switches['biome']
         if biome not in available_biome:
             biome = available_biome[0]
-        biome.lower()
+        biome = biome.lower()
 
         camp_bg_path_1 = f'{camp_bg_base_dir}/{biome}/{start_leave}_camp1_{light_dark}.png'
         camp_bg_path_2 = f'{camp_bg_base_dir}/{biome}/{start_leave}_camp2_{light_dark}.png'

--- a/scripts/screens/clan_screens.py
+++ b/scripts/screens/clan_screens.py
@@ -153,7 +153,7 @@ class ClanScreen(Screens):
         if biome not in available_biome:
             biome = available_biome[0]
             game.clan.biome = biome
-        biome.lower()
+        biome = biome.lower()
 
         all_backgrounds = []
         for leaf in leaves:


### PR DESCRIPTION
Changes a few instances of ``biome.lower()``, which just returns the variable, to actually change the variable with ``biome = biome.lower()``.

Currently, the game crashes on case-sensitive filesystems whenever it tries to load a resource from ``resources/images/camp_bg``:
```
Traceback (most recent call last):
  File "/home/user/clangen/main.py", line 266, in <module>
    game.all_screens[game.current_screen].on_use()
  File "/home/user/clangen/scripts/screens/clan_creation_screens.py", line 715, in on_use
    self.sixth_phase()
  File "/home/user/clangen/scripts/screens/clan_creation_screens.py", line 561, in sixth_phase
    self.choose_camp()
  File "/home/user/clangen/scripts/screens/clan_creation_screens.py", line 590, in choose_camp
    self.camp_art()
  File "/home/user/clangen/scripts/screens/clan_creation_screens.py", line 690, in camp_art
    self.change_camp_art(camp_bg_path_1,camp_bg_path_2)
  File "/home/user/clangen/scripts/screens/clan_creation_screens.py", line 694, in change_camp_art
    pygame.image.load(arg0).convert(), (450, 400))
FileNotFoundError: No file 'resources/images/camp_bg//Forest/newleaf_camp1_light.png' found in working directory '/home/user/clangen'.

```