### PR TITLE
fix: Med cats changing traits

### DIFF
--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -88,7 +88,8 @@ class Clan(object):
                 self.clan_cats.append(self.deputy.ID)
             self.deputy_predecessors = 0
             self.medicine_cat = medicine_cat
-            self.medicine_cat.status_change('medicine cat')
+            if medicine_cat and medicine_cat.status != 'medicine cat': 
+                self.medicine_cat.status_change('medicine cat')
             self.med_cat_predecessors = 0
             self.clan_cats.append(self.medicine_cat.ID)
             self.age = 0


### PR DESCRIPTION
status_change() rerolls traits for medicine cats. It shouldn't be called when loading saves unless it has to be.