### PR TITLE
Apply some basic pylint-recommended optimizations ( + 2 minor fixes & a py3 shebang )

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 import os
 directory = os.path.dirname(__file__)
@@ -10,7 +11,7 @@ from scripts.cat.sprites import sprites
 #from scripts.world import load_map
 from scripts.clan import clan_class
 
-# import all screens for initialization 
+# import all screens for initialization
 from scripts.screens.all_screens import *
 
 # P Y G A M E

--- a/scripts/cat/appearance_utility.py
+++ b/scripts/cat/appearance_utility.py
@@ -270,7 +270,7 @@ def init_pattern(cat):
         cat.pattern = None
 
 def init_white_patches(cat):
-    if cat.pelt is not None:
+    if cat.pelt is None:
         init_pelt(cat)
     non_white_pelt = False
     if cat.pelt.colour != 'WHITE' and cat.pelt.name in\

--- a/scripts/cat/appearance_utility.py
+++ b/scripts/cat/appearance_utility.py
@@ -7,114 +7,114 @@ from .pelts import *
 def plural_acc_names(accessory, plural, singular):
     acc_display = accessory.lower()
     if acc_display == 'maple leaf':
-        if plural == True:
+        if plural:
             acc_display = 'maple leaves'
-        if singular == True:
+        if singular:
             acc_display = 'maple leaf'
     elif acc_display == 'holly':
-        if plural == True:
+        if plural:
             acc_display = 'holly berries'
-        if singular == True:
+        if singular:
             acc_display = 'holly berry'
     elif acc_display == 'blue berries':
-        if plural == True:
+        if plural:
             acc_display = 'blueberries'
-        if singular == True:
+        if singular:
             acc_display = 'blueberry'
     elif acc_display == 'forget me nots':
-        if plural == True:
+        if plural:
             acc_display = 'forget me nots'
-        if singular == True:
+        if singular:
             acc_display = 'forget me not flower'
     elif acc_display == 'rye stalk':
-        if plural == True:
+        if plural:
             acc_display = 'rye stalks'
-        if singular == True:
+        if singular:
             acc_display = 'rye stalk'
     elif acc_display == 'laurel':
-        if plural == True:
+        if plural:
             acc_display = 'laurel'
-        if singular == True:
+        if singular:
             acc_display = 'laurel plant'
     elif acc_display == 'bluebells':
-        if plural == True:
+        if plural:
             acc_display = 'bluebells'
-        if singular == True:
+        if singular:
             acc_display = 'bluebell flower'
     elif acc_display == 'nettle':
-        if plural == True:
+        if plural:
             acc_display = 'nettles'
-        if singular == True:
+        if singular:
             acc_display = 'nettle'
     elif acc_display == 'poppy':
-        if plural == True:
+        if plural:
             acc_display = 'poppies'
-        if singular == True:
+        if singular:
             acc_display = 'poppy flower'
     elif acc_display == 'lavender':
-        if plural == True:
+        if plural:
             acc_display = 'lavender'
-        if singular == True:
+        if singular:
             acc_display = 'lavender flower'
     elif acc_display == 'herbs':
-        if plural == True:
+        if plural:
             acc_display = 'herbs'
-        if singular == True:
+        if singular:
             acc_display = 'herb'
     elif acc_display == 'petals':
-        if plural == True:
+        if plural:
             acc_display = 'petals'
-        if singular == True:
+        if singular:
             acc_display = 'petal'
     elif acc_display == 'dry herbs':
-        if plural == True:
+        if plural:
             acc_display = 'dry herbs'
-        if singular == True:
+        if singular:
             acc_display = 'dry herb'
     elif acc_display == 'oak leaves':
-        if plural == True:
+        if plural:
             acc_display = 'oak leaves'
-        if singular == True:
+        if singular:
             acc_display = 'oak leaf'
     elif acc_display == 'catmint':
-        if plural == True:
+        if plural:
             acc_display = 'catnip'
-        if singular == True:
+        if singular:
             acc_display = 'catnip sprig'
     elif acc_display == 'maple seed':
-        if plural == True:
+        if plural:
             acc_display = 'maple seeds'
-        if singular == True:
+        if singular:
             acc_display = 'maple seed'
     elif acc_display == 'juniper':
-        if plural == True:
+        if plural:
             acc_display = 'juniper berries'
-        if singular == True:
+        if singular:
             acc_display = 'juniper berry'
     elif acc_display == 'red feathers':
-        if plural == True:
+        if plural:
             acc_display = 'cardinal feathers'
-        if singular == True:
+        if singular:
             acc_display = 'cardinal feather'
     elif acc_display == 'blue feathers':
-        if plural == True:
+        if plural:
             acc_display = 'crow feathers'
-        if singular == True:
+        if singular:
             acc_display = 'crow feather'
     elif acc_display == 'jay feathers':
-        if plural == True:
+        if plural:
             acc_display = 'jay feathers'
-        if singular == True:
+        if singular:
             acc_display = 'jay feather'
     elif acc_display == 'moth wings':
-        if plural == True:
+        if plural:
             acc_display = 'moth wings'
-        if singular == True:
+        if singular:
             acc_display = 'moth wing'
     elif acc_display == 'cicada wings':
-        if plural == True:
+        if plural:
             acc_display = 'cicada wings'
-        if singular == True:
+        if singular:
             acc_display = 'cicada wing'
 
     if plural is True and singular is False:
@@ -127,7 +127,7 @@ def plural_acc_names(accessory, plural, singular):
 # ---------------------------------------------------------------------------- #
 
 def init_eyes(cat):
-    if cat.eye_colour != None:
+    if cat.eye_colour is not None:
         return
     hit = randint(0, 200)
     if hit == 1:
@@ -148,7 +148,7 @@ def init_eyes(cat):
             ])
 
 def init_pelt(cat):
-    if cat.pelt != None:
+    if cat.pelt is not None:
         return
 
     if cat.parent2 is None and cat.parent1 in cat.all_cats.keys():
@@ -166,7 +166,7 @@ def init_pelt(cat):
         cat.pelt = choose_pelt(cat.gender)
 
 def init_sprite(cat):
-    if cat.pelt == None:
+    if cat.pelt is None:
         init_pelt(cat)
     cat.age_sprites = {
         'kitten': randint(0, 2),
@@ -216,7 +216,7 @@ def init_scars(cat):
         cat.specialty2 = None
     if cat.specialty2 == 'NOTAIL':
         if cat.specialty == 'HALFTAIL':
-            cat.specialty == None
+            cat.specialty = None
 
 def init_accessories(cat):
     acc_display_choice = randint(0, 35)
@@ -233,7 +233,7 @@ def init_accessories(cat):
         cat.acc_display = None
 
 def init_pattern(cat):
-    if cat.pelt == None:
+    if cat.pelt is None:
         init_pelt(cat)
     if cat.pelt.name in ['Calico', 'Tortie']:
         cat.tortiecolour = cat.pelt.colour
@@ -258,7 +258,7 @@ def init_pattern(cat):
         cat.tortiebase = None
         cat.tortiepattern = None
         cat.tortiecolour = None
-    if cat.pelt.name in ['Calico', 'Tortie'] and cat.pelt.colour != None:
+    if cat.pelt.name in ['Calico', 'Tortie'] and cat.pelt.colour is not None:
         if cat.pelt.colour in ["BLACK", "DARKBROWN"]:
             cat.pattern = choice(['GOLDONE', 'GOLDTWO', 'GOLDTHREE', 'GOLDFOUR', 'GINGERONE', 'GINGERTWO', 'GINGERTHREE', 'GINGERFOUR',
                                     'DARKONE', 'DARKTWO', 'DARKTHREE', 'DARKFOUR'])
@@ -270,7 +270,7 @@ def init_pattern(cat):
         cat.pattern = None
 
 def init_white_patches(cat):
-    if cat.pelt == None:
+    if cat.pelt is not None:
         init_pelt(cat)
     non_white_pelt = False
     if cat.pelt.colour != 'WHITE' and cat.pelt.name in\
@@ -304,7 +304,7 @@ def init_white_patches(cat):
                     cat.white_patches = choice([None] + little_white_poss + mid_white_poss + high_white_poss + mostly_white_poss)
                 elif par1.white_patches in mostly_white:
                     cat.white_patches = choice(mid_white + high_white + mostly_white + ['FULLWHITE'])
-            if par1.white_patches == None and cat.pelt.name == 'Calico':
+            if par1.white_patches is None and cat.pelt.name == 'Calico':
                 cat.pelt.name = 'Tortie'
             # two parents
         elif cat.parent1 is not None and cat.parent2 is not None and\
@@ -449,7 +449,7 @@ def init_white_patches(cat):
                 else:
                     cat.white_patches = None
         # just making sure no cats end up with no white patches and true white            
-        if cat.white_patches == None:
+        if cat.white_patches is None:
             cat.white = False
     else:
         cat.white_patches = None

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -15,7 +15,7 @@ from scripts.game_structure.game_essentials import *
 from scripts.cat_relations.relationship import *
 
 
-class Cat(object):
+class Cat():
     used_screen = screen
     traits = [
         'adventurous', 'altruistic', 'ambitious', 'bloodthirsty', 'bold',
@@ -138,7 +138,7 @@ class Cat(object):
         # age and status
         if status is None and moons is None:
             self.age = choice(self.ages)
-        elif moons != None:
+        elif moons is not None:
             for key_age in self.age_moons.keys():
                 if moons in range(self.age_moons[key_age][0], self.age_moons[key_age][1]+1):
                     self.age = key_age
@@ -215,7 +215,7 @@ class Cat(object):
         self.paralyzed = False
         self.no_kits = False
         self.exiled = False
-        if self.genderalign == None:
+        if self.genderalign is None:
             self.genderalign = self.gender
 
         # Sprite sizes
@@ -243,7 +243,7 @@ class Cat(object):
         self.paralyzed = False
         self.no_kits = False
         self.exiled = False
-        if self.genderalign == None:
+        if self.genderalign is None:
             self.genderalign = self.gender
 
         # SAVE CAT INTO ALL_CATS DICTIONARY IN CATS-CLASS
@@ -264,7 +264,7 @@ class Cat(object):
         else:
             self.dead = True
 
-        if self.mate != None:
+        if self.mate is None:
             self.mate = None
             if type(self.mate) == str:
                 mate = Cat.all_cats.get(self.mate)
@@ -472,14 +472,14 @@ class Cat(object):
                 lambda relation: str(relation.cat_to) == str(random_id) and
                 not relation.cat_to.dead, self.relationships))
         random_cat = self.all_cats.get(random_id)
-        kitten_and_exiled = random_cat != None and random_cat.exiled and self.age == "kitten"
+        kitten_and_exiled = random_cat is not None and random_cat.exiled and self.age == "kitten"
 
         # is also found in Relation_Events.MAX_ATTEMPTS
         attempts_left = 1000
         while len(relevant_relationship_list) < 1 or random_id == self.ID or kitten_and_exiled:
             random_id = random.choice(cats_to_choose)
             random_cat = self.all_cats.get(random_id)
-            kitten_and_exiled = random_cat != None and random_cat.exiled and self.age == "kitten"
+            kitten_and_exiled = random_cat is not None and random_cat.exiled and self.age == "kitten"
             relevant_relationship_list = list(
                 filter(
                     lambda relation: str(relation.cat_to) == str(random_id) and
@@ -561,14 +561,14 @@ class Cat(object):
         right_parents = []
         if len(parents) == 2:
             left_p = Cat.all_cats.get(parents[0])
-            if left_p != None:
+            if left_p is not None:
                 left_parents = left_p.get_parents()
             right_p = Cat.all_cats.get(parents[1])
-            if right_p != None:
+            if right_p is not None:
                 right_parents = right_p.get_parents()
         if len(parents) == 1:
             left_p = Cat.all_cats.get(parents[0])
-            if left_p != None:
+            if left_p is not None:
                 left_parents = left_p.get_parents()
 
         if self.ID in left_parents or self.ID in right_parents:
@@ -642,14 +642,14 @@ class Cat(object):
         )
 
     def is_ill(self):
-        return self.illness != None
+        return self.illness is not None
 
     def is_injured(self):
-        return self.injury != None
+        return self.injury is not None
 
     def contact_with_ill_cat(self, cat):
         "handles if one cat had contact with a ill cat"
-        if self.is_ill() or cat == None or not cat.is_ill() or cat.illness.infectiousness == 0:
+        if self.is_ill() or cat is None or not cat.is_ill() or cat.illness.infectiousness == 0:
             return
 
         illness_name = cat.illness.name
@@ -957,7 +957,7 @@ class Cat(object):
             clanname = game.switches['clan_name']
         elif len(game.switches['clan_name']) > 0:
             clanname = game.switches['clan_list'][0]
-        elif game.clan != None:
+        elif game.clan is not None:
             clanname = game.clan.name
         relationship_dir = 'saves/' + clanname + '/relationships'
         if not os.path.exists(relationship_dir):
@@ -1012,7 +1012,7 @@ class Cat(object):
                     relationships = []
                     for rel in rel_data:
                         cat_to = self.all_cats.get(rel['cat_to_id'])
-                        if cat_to == None:
+                        if cat_to is None:
                             continue
                         new_rel = Relationship(
                             cat_from=self,
@@ -1066,7 +1066,7 @@ class Cat(object):
             if self._moons in range(self.age_moons[key_age][0], self.age_moons[key_age][1]+1):
                 updated_age = True
                 self.age = key_age
-        if not updated_age and self.age != None:
+        if not updated_age and self.age is not None:
             self.age = "elder"
 
 # ---------------------------------------------------------------------------- #

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -264,7 +264,7 @@ class Cat():
         else:
             self.dead = True
 
-        if self.mate is None:
+        if self.mate is not None:
             self.mate = None
             if type(self.mate) == str:
                 mate = Cat.all_cats.get(self.mate)

--- a/scripts/cat/names.py
+++ b/scripts/cat/names.py
@@ -2,7 +2,7 @@ import random
 import os
 
 
-class Name(object):
+class Name():
     special_suffixes = {
         "kitten": "kit",
         "apprentice": "paw",

--- a/scripts/cat/pelts.py
+++ b/scripts/cat/pelts.py
@@ -1,7 +1,7 @@
 from random import choice, randint
 
 
-class SingleColour(object):
+class SingleColour():
     name = "SingleColour"
     sprites = {1: 'single'}
     white_patches = None
@@ -14,7 +14,7 @@ class SingleColour(object):
     def __repr__(self):
         return self.colour + self.length
 
-class TwoColour(object):
+class TwoColour():
     name = "TwoColour"
     sprites = {1: 'single', 2: 'white'}
     white_patches = [
@@ -39,7 +39,7 @@ class TwoColour(object):
     def __repr__(self):
         return f"white and {self.colour}{self.length}"
 
-class Tabby(object):
+class Tabby():
     name = "Tabby"
     sprites = {1: 'tabby', 2: 'white'}
     white_patches = [
@@ -66,7 +66,7 @@ class Tabby(object):
         else:
             return self.colour + self.length + " tabby"
 
-class Marbled(object):
+class Marbled():
     name = "Marbled"
     sprites = {1: 'marbled', 2: 'white'}
     white_patches = [
@@ -93,7 +93,7 @@ class Marbled(object):
         else:
             return self.colour + self.length + " marbled"
 
-class Rosette(object):
+class Rosette():
     name = "Rosette"
     sprites = {1: 'rosette', 2: 'white'}
     white_patches = [
@@ -120,7 +120,7 @@ class Rosette(object):
         else:
             return self.colour + self.length + " rosette"
 
-class Smoke(object):
+class Smoke():
     name = "Smoke"
     sprites = {1: 'smoke', 2: 'white'}
     white_patches = [
@@ -148,7 +148,7 @@ class Smoke(object):
         else:
             return self.colour + self.length + " smoke"
 
-class Ticked(object):
+class Ticked():
     name = "Ticked"
     sprites = {1: 'ticked', 2: 'white'}
     white_patches = [
@@ -176,7 +176,7 @@ class Ticked(object):
         else:
             return self.colour + self.length + " ticked"
 
-class Speckled(object):
+class Speckled():
     name = "Speckled"
     sprites = {1: 'speckled', 2: 'white'}
     white_patches = [
@@ -203,7 +203,7 @@ class Speckled(object):
         else:
             return f"{self.colour} speckled{self.length}"
 
-class Bengal(object):
+class Bengal():
     name = "Bengal"
     sprites = {1: 'bengal', 2: 'white'}
     white_patches = [
@@ -231,7 +231,7 @@ class Bengal(object):
         else:
             return f"{self.colour} bengal{self.length}"
 
-class Tortie(object):
+class Tortie():
     name = "Tortie"
     sprites = {1: 'tortie', 2: 'white'}
     white_patches = [
@@ -254,7 +254,7 @@ class Tortie(object):
         else:
             return f"tortoiseshell{self.length}"
 
-class Calico(object):
+class Calico():
     name = "Calico"
     sprites = {1: 'calico', 2: 'white'}
     white_patches = [
@@ -441,7 +441,7 @@ def choose_pelt(gender,colour=None,white=None,pelt=None,length=None,determined=F
 def describe_color(pelt, tortiecolour, tortiepattern, white_patches):
         color_name = ''
         color_name = str(pelt.colour).lower()
-        if tortiecolour != None:
+        if tortiecolour is not None:
             color_name = str(tortiecolour).lower()
         if color_name == 'palegrey':
             color_name = 'pale grey'

--- a/scripts/cat/sprites.py
+++ b/scripts/cat/sprites.py
@@ -2,7 +2,7 @@ import pygame
 
 from scripts.game_structure.game_essentials import *
 
-class Sprites(object):
+class Sprites():
 
     def __init__(self, original_size, new_size=None):
         self.size = original_size  # size of a single sprite in a spritesheet

--- a/scripts/cat/thoughts.py
+++ b/scripts/cat/thoughts.py
@@ -4,7 +4,7 @@ def get_thoughts(cat, other_cat):
     # placeholder thought - should only appear in game, when there is only one cat left
     thoughts = ['Is not thinking about much right now']
 
-    if cat == None or other_cat == None:
+    if cat is None or other_cat is None:
         return thoughts
 
     # actions or thoughts for all cats. These switch either every moon or every time the game is re-opened

--- a/scripts/cat_relations/relation_events.py
+++ b/scripts/cat_relations/relation_events.py
@@ -1,13 +1,13 @@
 from scripts.utility import *
 from scripts.cat.cats import *
 
-class Relation_Events(object):
+class Relation_Events():
     """All relationship events."""
 
     MAX_ATTEMPTS = 1000
 
     def __init__(self) -> None:
-        self.living_cats = len(list(filter(lambda r: r.dead == False, Cat.all_cats.values())))
+        self.living_cats = len(list(filter(lambda r: not r.dead, Cat.all_cats.values())))
         self.event_sums = 0
         self.had_one_event = False
         pass
@@ -42,7 +42,7 @@ class Relation_Events(object):
             # get some cats to make easier checks
             cat_from = relationship.cat_from
             cat_from_mate = None
-            if cat_from.mate != None:
+            if cat_from.mate is not None:
                 if cat_from.mate not in Cat.all_cats.keys():
                     game.cur_events_list.insert(0, f"Cat #{cat_from} has a invalid mate. It will set to none.")
                     cat_from.mate = None
@@ -51,18 +51,18 @@ class Relation_Events(object):
 
             cat_to = relationship.cat_to
             cat_to_mate = None
-            if cat_to.mate != None:
+            if cat_to.mate is not None:
                 if cat_to.mate not in Cat.all_cats.keys():
                     game.cur_events_list.insert(0, f"Cat #{cat_to} has a invalid mate. It will set to none.")
                     cat_to.mate = None
                     return
                 cat_to_mate = Cat.all_cats.get(cat_to.mate)
 
-            if relationship.opposite_relationship == None:
+            if relationship.opposite_relationship is None:
                 relationship.link_relationship()
 
             # overcome dead mates
-            if cat_from_mate != None and cat_from_mate.dead and randint(1, 25) == 1 and cat_from_mate.dead_for >= 4:
+            if cat_from_mate is not None and cat_from_mate.dead and randint(1, 25) == 1 and cat_from_mate.dead_for >= 4:
                 self.had_one_event = True
                 game.cur_events_list.append(
                     f'{str(cat_from.name)} will always love {str(cat_from_mate.name)} but has decided to move on'
@@ -91,13 +91,13 @@ class Relation_Events(object):
                     bigger_than_current = relationship.romantic_love > mate_relationship[
                         0].romantic_love
                 else:
-                    if cat_from_mate != None:
+                    if cat_from_mate is not None:
                         cat_from_mate.relationships.append(
                             Relationship(cat_from, cat_from_mate, True))
                     bigger_than_current = True
 
                 # check cat to value
-                if cat_to_mate != None:
+                if cat_to_mate is not None:
                     opposite_mate_relationship = list(
                         filter(lambda r: r.cat_to.ID == cat_from.ID,
                                cat_to.relationships))
@@ -116,7 +116,7 @@ class Relation_Events(object):
                     cat_from_mate = Cat.all_cats.get(cat_from.mate)
                     self.check_if_breakup(cat_from, cat_from_mate)
 
-                    if cat_to_mate != None:
+                    if cat_to_mate is not None:
                         self.check_if_breakup(cat_to, cat_to_mate)
 
                     # new relationship
@@ -135,7 +135,7 @@ class Relation_Events(object):
 
     def handle_having_kits(self, cat, clan = game.clan):
         """Handles pregnancy of a cat."""
-        if clan == None:
+        if clan is None:
             return
         if cat.ID in clan.pregnancy_data.keys():
             moons = clan.pregnancy_data[cat.ID]["moons"]
@@ -236,7 +236,7 @@ class Relation_Events(object):
 
     def handle_breakup(self, relationship_from, relationship_to, cat_from, cat_to):
         from_mate_in_clan = False
-        if cat_from.mate != None:
+        if cat_from.mate is not None:
             if cat_from.mate not in Cat.all_cats.keys():
                 game.cur_events_list.insert(0, f"Cat #{cat_from} has a invalid mate. It will set to none.")
                 cat_from.mate = None
@@ -273,7 +273,7 @@ class Relation_Events(object):
 
         cat_to = highest_romantic_relation.cat_to
         if cat_to.is_potential_mate(cat, True) and cat.is_potential_mate(cat_to, True):
-            if cat_to.mate == None and cat.mate == None:
+            if cat_to.mate is None and cat.mate is None:
                 self.had_one_event = True
                 cat.set_mate(cat_to)
                 cat_to.set_mate(cat)
@@ -297,7 +297,7 @@ class Relation_Events(object):
 
     def handle_zero_moon_pregnant(self, cat, other_cat = None, relation = None, clan = game.clan):
         """Handles if the cat is zero moons pregnant."""
-        if other_cat != None and (other_cat.dead or other_cat.exiled or other_cat.birth_cooldown > 0):
+        if other_cat is not None and (other_cat.dead or other_cat.exiled or other_cat.birth_cooldown > 0):
             return
 
         chance = self.get_kits_chance(cat, other_cat, relation)
@@ -307,7 +307,7 @@ class Relation_Events(object):
         
         # even with no_gendered_breeding on a male cat with no second parent should not be count as pregnant
         # instead, the cat should get the kit instantly
-        if cat.gender == 'male' and other_cat == None:
+        if cat.gender == 'male' and other_cat is None:
             amount = self.get_amount_of_kits(cat)
             self.get_kits(amount, cat, None, clan)
             print_event = f"{str(cat.name)} brought a litter of {str(amount)} kit(s) back to camp, but refused to talk about their origin"
@@ -325,7 +325,7 @@ class Relation_Events(object):
 
         # if the other cat is a female and the current cat is a male, make the female cat pregnant
         pregnant_cat = cat
-        if cat.gender == 'male' and other_cat != None and other_cat.gender == 'female':
+        if cat.gender == 'male' and other_cat is not None and other_cat.gender == 'female':
             pregnant_cat = other_cat
             clan.pregnancy_data[other_cat.ID] = {
                 "second_parent": cat.ID,
@@ -387,7 +387,7 @@ class Relation_Events(object):
 
         # choose event string
         print_event = ""
-        if other_cat == None:
+        if other_cat is None:
             print_event = f"{str(cat.name)} had a litter of {str(kits_amount)} kit(s), but refused to talk about their origin"
         elif cat.mate == other_cat.ID:
             if cat.gender == 'female':
@@ -524,9 +524,9 @@ class Relation_Events(object):
 
         # change the change based on the personality
         get_along = get_personality_compatibility(cat_from, cat_to)
-        if get_along != None and get_along:
+        if get_along is not None and get_along:
             chance_number += 5
-        if get_along != None and not get_along:
+        if get_along is not None and not get_along:
             chance_number -= 10
 
         # change the chance based on the last interactions
@@ -562,12 +562,12 @@ class Relation_Events(object):
         old_male = False
         if cat.gender == 'male' and cat.age == 'elder':
             old_male = True
-        if other_cat != None and other_cat.gender == 'male' and other_cat.age == 'elder':
+        if other_cat is not None and other_cat.gender == 'male' and other_cat.age == 'elder':
             old_male = True
 
         # calculate the chance of having kits
         chance = 80
-        if other_cat != None:
+        if other_cat is not None:
             chance = 45
             if relation.romantic_love >= 50:
                 chance -= 5
@@ -599,7 +599,7 @@ class Relation_Events(object):
             Returns:
                 integer (number)
         """
-        if mate_relation == None:
+        if mate_relation is None:
             return 0
 
         affair_chance = 100
@@ -621,7 +621,7 @@ class Relation_Events(object):
     def get_second_parent(self, cat, mate = None, affair = game.settings['affair']):
         """ Return the second parent of a cat, which will have kits."""
         second_parent = mate
-        if not affair or mate == None:
+        if not affair or mate is None:
             # if the cat has no mate, None will be returned
             return second_parent
 
@@ -633,7 +633,7 @@ class Relation_Events(object):
             cat.relationships.append(mate_relation)
 
         highest_romantic_relation = get_highest_romantic_relation(cat.relationships)
-        if highest_romantic_relation == None:
+        if highest_romantic_relation is None:
             return second_parent
 
         if highest_romantic_relation.cat_to.ID == mate.ID:
@@ -656,7 +656,7 @@ class Relation_Events(object):
         all_kitten = []
         for kit in range(kits_amount):
             kit = None
-            if other_cat != None:
+            if other_cat is not None:
                 if cat.gender == 'female':
                     kit = Cat(parent1=cat.ID, parent2=other_cat.ID, moons=0)
                     all_kitten.append(kit)

--- a/scripts/cat_relations/relationship.py
+++ b/scripts/cat_relations/relationship.py
@@ -37,7 +37,7 @@ COMPATIBILITY_WEIGHT = 3
 #                           START Relationship class                           #
 # ---------------------------------------------------------------------------- #
 
-class Relationship(object):
+class Relationship():
     def __init__(self, cat_from, cat_to, mates=False, family=False, romantic_love=0, platonic_like=0, dislike=0, admiration=0, comfortable=0, jealousy=0, trust=0, log = []) -> None:        
         self.cat_from = cat_from
         self.cat_to = cat_to
@@ -60,7 +60,7 @@ class Relationship(object):
                 platonic_like = 20
                 comfortable = 10
 
-        if self.cat_from.mate != None and self.cat_from.mate == self.cat_to.ID:
+        if self.cat_from.mate is not None and self.cat_from.mate == self.cat_to.ID:
             self.mates = True
             if romantic_love == 0:
                 romantic_love = 20
@@ -220,7 +220,7 @@ class Relationship(object):
         if self.platonic_like > 30 or love_p == 1 or self.romantic_love > 5:
             # increase the chance of an love event for two un-mated cats
             action_possibilities = action_possibilities + LOVE['love_interest_only']
-            if self.cat_from.mate == None and self.cat_to.mate == None:
+            if self.cat_from.mate is None and self.cat_to.mate is None:
                 action_possibilities = action_possibilities + LOVE['love_interest_only']
 
         if self.opposite_relationship.romantic_love > 20:
@@ -396,7 +396,7 @@ class Relationship(object):
 
     def get_high_increase_value(self):
         compatibility = get_personality_compatibility(self.cat_from,self.cat_to)
-        if compatibility == None:
+        if compatibility is None:
             return DIRECT_INCREASE_HIGH
         if compatibility:
             return DIRECT_INCREASE_HIGH + COMPATIBILITY_WEIGHT
@@ -405,7 +405,7 @@ class Relationship(object):
 
     def get_high_decrease_value(self):
         compatibility = get_personality_compatibility(self.cat_from,self.cat_to)
-        if compatibility == None:
+        if compatibility is None:
             return DIRECT_DECREASE_HIGH
         if compatibility:
             return DIRECT_DECREASE_HIGH + COMPATIBILITY_WEIGHT
@@ -414,7 +414,7 @@ class Relationship(object):
 
     def get_low_increase_value(self):
         compatibility = get_personality_compatibility(self.cat_from,self.cat_to)
-        if compatibility == None:
+        if compatibility is None:
             return DIRECT_INCREASE_LOW
         if compatibility:
             return DIRECT_INCREASE_LOW + COMPATIBILITY_WEIGHT
@@ -423,7 +423,7 @@ class Relationship(object):
 
     def get_low_decrease_value(self):
         compatibility = get_personality_compatibility(self.cat_from,self.cat_to)
-        if compatibility == None:
+        if compatibility is None:
             return DIRECT_DECREASE_LOW
         if compatibility:
             return DIRECT_DECREASE_LOW + COMPATIBILITY_WEIGHT

--- a/scripts/clan.py
+++ b/scripts/clan.py
@@ -10,7 +10,7 @@ except:
 from sys import exit
 
 
-class Clan(object):
+class Clan():
     leader_lives = 0
     clan_cats = []
     starclan_cats = []
@@ -357,7 +357,7 @@ class Clan(object):
         game.switches['error_message'] = ''
 
     def load_pregnancy(self, clan):
-        if game.clan.name == False:
+        if not game.clan.name:
             return
         file_path = f"saves/{game.clan.name}/pregnancy.json"
         if os.path.exists(file_path):
@@ -367,7 +367,7 @@ class Clan(object):
             clan.pregnancy_data = {}
 
     def save_pregnancy(self, clan):
-        if game.clan.name == False:
+        if not game.clan.name:
             return
         file_path = f"saves/{game.clan.name}/pregnancy.json"
         try:
@@ -377,7 +377,7 @@ class Clan(object):
         except:
             print(f"Saving the pregnancy data didn't work.")
 
-class OtherClan(object):
+class OtherClan():
 
     def __init__(self, name='', relations=0, temperament=''):
         self.name = name or choice(names.normal_prefixes)
@@ -392,7 +392,7 @@ class OtherClan(object):
         return f"{self.name}Clan"
 
 
-class StarClan(object):
+class StarClan():
     forgotten_stages = {
         0: [0, 100],
         10: [101, 200],

--- a/scripts/conditions.py
+++ b/scripts/conditions.py
@@ -1,5 +1,3 @@
-import ujson
-
 from scripts.game_structure.game_essentials import game
 
 
@@ -26,7 +24,7 @@ def medical_cats_condition_fulfilled(number_medicine_cats, number_medicine_appre
 #                                    Illness                                   #
 # ---------------------------------------------------------------------------- #
 
-class Illness(object):
+class Illness():
     def _init_(self, 
             name, 
             mortality, 
@@ -79,7 +77,7 @@ class Illness(object):
 #                                   Injuries                                   #
 # ---------------------------------------------------------------------------- #
 
-class Injury(object):
+class Injury():
     def _init_(self, 
             name,
             duration,

--- a/scripts/events.py
+++ b/scripts/events.py
@@ -3,7 +3,7 @@ from scripts.cat_relations.relation_events import *
 from scripts.game_structure.buttons import *
 from scripts.game_structure.load_cat import * 
 
-class Events(object):
+class Events():
     all_events = {}
 
     def __init__(self, e_type=None, **cats):
@@ -40,11 +40,11 @@ class Events(object):
                     elif cat.moons == 100:
                         cat.age = 'elder'
                     if cat.moons > randint(100, 200):
-                        if choice([1, 2, 3, 4, 5]) == 1 and cat.dead == False:
+                        if choice([1, 2, 3, 4, 5]) == 1 and not cat.dead:
                             cat.dead = True
                             game.cur_events_list.append(f'Rumors reach your clan that the exiled {str(cat.name)} has died recently')
 
-                    if cat.exiled and cat.status == 'leader' and cat.dead == False and randint(
+                    if cat.exiled and cat.status == 'leader' and not cat.dead and randint(
                             1, 10) == 1:
                         game.clan.leader_lives -= 1
                         if game.clan.leader_lives <= 0:
@@ -52,7 +52,7 @@ class Events(object):
                             game.cur_events_list.append(f'Rumors reach your clan that the exiled {str(cat.name)} has died recently')
 
                             game.clan.leader_lives = 0
-                    elif cat.exiled and cat.status == 'leader' and cat.dead == False and randint(
+                    elif cat.exiled and cat.status == 'leader' and not cat.dead and randint(
                             1, 45) == 1:
                         game.clan.leader_lives -= 10
                         cat.dead = True
@@ -95,7 +95,7 @@ class Events(object):
 
         self.perform_ceremonies(cat) # here is age up included
         self.handle_deaths(cat)
-        if self.new_cat_invited == False or self.living_cats < 10:
+        if not self.new_cat_invited or self.living_cats < 10:
             self.invite_new_cats(cat)
         self.other_interactions(cat)
         self.coming_out(cat)
@@ -431,7 +431,7 @@ class Events(object):
                         f'{name} lost their paw to a twoleg trap'
                     )
                 else:
-                    if clan_has_kits == True:
+                    if clan_has_kits:
                         scar_text.extend([
                         f'{name} earned a scar protecting the kits'])
                     else:
@@ -465,7 +465,7 @@ class Events(object):
                             'enemy warrior', 'badger', 'tree', 'twoleg trap'
                         ]) + ' encouraged by their mentor')
                 else:
-                    if clan_has_kits == True:
+                    if clan_has_kits:
                         scar_text.extend([
                         f'{name} earned a scar protecting the kits'])
                     else:
@@ -501,7 +501,7 @@ class Events(object):
                         'enemy warrior', 'badger', 'tree', 'twoleg trap'
                     ]) + ' encouraged by their mentor')
                 else:
-                    if clan_has_kits == True:
+                    if clan_has_kits:
                         scar_text.extend([
                         f'{name} earned a scar protecting the kits'])
                     else:
@@ -1058,7 +1058,7 @@ class Events(object):
                 name + ' was found dead near a fox den',
                 name + ' was bitten by a snake and died'
             ]
-            if clan_has_kits == True and cat.status != 'kitten':
+            if clan_has_kits and cat.status != 'kitten':
                 cause_of_death.extend([
                     name + ' was bitten by a snake while saving a kit and died'
                 ])
@@ -1389,6 +1389,7 @@ class Events(object):
             if len(game.clan.all_clans) > 0:
                 other_clan = game.clan.all_clans
             addition = randint(0, 20)
+            # Are death_chance & dead_count unused? Should maybe be removed if so... -Shou
             death_chance = int(alive_count / 3)
             if addition == 1:
                 death_chance = int(death_chance + randint(0, 10) / 2)
@@ -1527,7 +1528,7 @@ class Events(object):
                 elif transing_chance == 2:
                     cat.genderalign = "nonbinary"
                     hit = True
-            if hit == True:
+            if hit:
                 if cat.gender == 'male':
                     gender = 'tom'
                 else:

--- a/scripts/game_structure/buttons.py
+++ b/scripts/game_structure/buttons.py
@@ -5,7 +5,7 @@ from .game_essentials import *
 from scripts.cat.cats import Cat
 
 
-class Button(object):
+class Button():
     used_screen = screen
     used_mouse = mouse
 

--- a/scripts/game_structure/game_essentials.py
+++ b/scripts/game_structure/game_essentials.py
@@ -11,7 +11,7 @@ pygame.display.set_caption('Clan Generator')
 
 
 # G A M E
-class Game(object):
+class Game():
     # Text box variables
     naming_box = pygame.Surface((140, 20))
     naming_box.fill((230, 230, 230))
@@ -261,7 +261,7 @@ class Game(object):
             clanname = game.switches['clan_name']
         elif len(game.switches['clan_name']) > 0:
             clanname = game.switches['clan_list'][0]
-        elif game.clan != None:
+        elif game.clan is not None:
             clanname = game.clan.name
         directory = 'saves/' + clanname
         if not os.path.exists(directory):
@@ -326,7 +326,7 @@ class Game(object):
             print("Saving cats didn't work.")
 
 # M O U S E
-class Mouse(object):
+class Mouse():
     used_screen = screen
 
     def __init__(self):

--- a/scripts/game_structure/load_cat.py
+++ b/scripts/game_structure/load_cat.py
@@ -84,7 +84,7 @@ def json_load():
             cat.load_relationship_of_cat()
             game.switches[
                 'error_message'] = f'There was an error when relationships for cat #{cat} are created.'
-            if cat.relationships != None and len(cat.relationships) < 1:
+            if cat.relationships is not None and len(cat.relationships) < 1:
                 cat.create_new_relationships()
         else:
             cat.relationships = []
@@ -314,7 +314,7 @@ def csv_load(all_cats):
                 the_cat = all_cats.get(id)
                 game.switches[
                     'error_message'] = f'There was an error when relationships for cat #{the_cat} are created.'
-                if the_cat.relationships != None and len(
+                if the_cat.relationships is not None and len(
                         the_cat.relationships) < 1:
                     the_cat.create_new_relationships()
         game.switches['error_message'] = ''

--- a/scripts/game_structure/text.py
+++ b/scripts/game_structure/text.py
@@ -4,7 +4,7 @@ from .game_essentials import game, screen, screen_x, screen_y
 pygame.init()
 
 
-class Font(object):
+class Font():
     used_screen = screen  # The surface to draw the text on
     extra = 0  # Add extra size to text for readability
     extra_space = 0  # Extra size means extra space between text may be needed

--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -10,7 +10,7 @@ from scripts.cat.pelts import *
 #                              PATROL CLASS START                              #
 # ---------------------------------------------------------------------------- #
 
-class Patrol(object):
+class Patrol():
 
     def __init__(self):
         self.patrol_event = None
@@ -228,14 +228,14 @@ class Patrol(object):
                 ])
 
         # deadly patrols
-        if game_setting_disaster == True:
+        if game_setting_disaster:
             possible_patrols.extend(self.generate_patrol_events(DISASTER))
 
         # fighting patrols
         possible_patrols.extend(self.generate_patrol_events(GENERAL_FIGHTING))
 
 
-        if self.patrol_random_cat != None and self.patrol_random_cat.status == 'apprentice' and len(
+        if self.patrol_random_cat is not None and self.patrol_random_cat.status == 'apprentice' and len(
                 self.patrol_cats) > 1:
             possible_patrols.extend([
                 PatrolEvent(
@@ -982,7 +982,7 @@ class Patrol(object):
 #                               PATROL CLASS END                               #
 # ---------------------------------------------------------------------------- #
 
-class PatrolEvent(object):
+class PatrolEvent():
 
     def __init__(self,
                  patrol_id,

--- a/scripts/screens/base_screens.py
+++ b/scripts/screens/base_screens.py
@@ -4,7 +4,7 @@ from scripts.game_structure.buttons import buttons
 from scripts.game_structure.game_essentials import *
 from scripts.clan import map_available
 
-class Screens(object):
+class Screens():
     game_screen = screen
     game_x = screen_x
     game_y = screen_y

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -27,7 +27,7 @@ def accessory_display_name(cat, accessory):
     if accessory is None:
         return ''
     acc_display = accessory.lower()
-    if accessory != None:
+    if accessory is not None:
         if accessory in collars:
             collar_color = None
             if acc_display.startswith('crimson'):
@@ -72,7 +72,7 @@ def accessory_display_name(cat, accessory):
             acc_display = acc_display
     else:
         acc_display = acc_display
-    if accessory == None:
+    if accessory is None:
         acc_display = None
     return acc_display
 
@@ -123,7 +123,7 @@ class ProfileScreen(Screens):
             verdana.text(second_part, ('center', 200))
 
         
-        if the_cat.genderalign == None or the_cat.genderalign == True or the_cat.genderalign == False:
+        if the_cat.genderalign is None or the_cat.genderalign or not the_cat.genderalign:
             verdana_small.text(str(the_cat.gender), (300, 230 + count * 15))
         else:
             verdana_small.text(str(the_cat.genderalign), (300, 230 + count * 15))
@@ -599,7 +599,7 @@ class OptionsScreen(Screens):
                                 hotkey=[button_count + 1])
             button_count += 1
             
-        if the_cat.accessory != None:
+        if the_cat.accessory is not None:
             buttons.draw_button((x_value, y_value + button_count * y_change),
                                 text='Remove accessory',
                                 cat_value=the_cat,

--- a/scripts/screens/clan_screens.py
+++ b/scripts/screens/clan_screens.py
@@ -144,7 +144,7 @@ class ClanScreen(Screens):
         camp_bg_base_dir = 'resources/images/camp_bg/'
         leaves = ["newleaf", "greenleaf", "leafbare", "leaffall"]
         camp_nr = game.clan.camp_bg
-        if camp_nr == None:
+        if camp_nr is None:
             camp_nr = 'camp1'
             game.clan.camp_bg = camp_nr
         

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -473,7 +473,7 @@ class ChooseMateScreen(Screens):
 
             not_aviable = relevant_cat.dead or relevant_cat.exiled
 
-            if not related and relevant_cat.ID != the_cat.ID and invalid_age and not not_aviable and relevant_cat.mate == None:
+            if not related and relevant_cat.ID != the_cat.ID and invalid_age and not not_aviable and relevant_cat.mate is None:
                 valid_mates.append(relevant_cat)
         all_pages = int(ceil(len(valid_mates) /
                              27.0)) if len(valid_mates) > 27 else 1
@@ -567,9 +567,9 @@ class RelationshipScreen(Screens):
 
         # layout
         verdana_big.text(str(the_cat.name) + ' Relationships', ('center', 10))
-        if the_cat != None and the_cat.mate != '':
+        if the_cat is not None and the_cat.mate != '':
             mate = Cat.all_cats.get(the_cat.mate)
-            if mate != None:
+            if mate is not None:
                 verdana_small.text(
                     f"{str(the_cat.genderalign)}  - {str(the_cat.age)} -  mate: {str(mate.name)}",
                     ('center', 40))
@@ -635,10 +635,10 @@ class RelationshipScreen(Screens):
                 (140 + pos_x - string_len / 1.5, 130 + pos_y))
 
             # display mate situation
-            if the_cat.mate != None and the_cat.mate != '' and the_relationship.cat_to.ID == the_cat.mate:
+            if the_cat.mate is not None and the_cat.mate != '' and the_relationship.cat_to.ID == the_cat.mate:
                 verdana_small.text(
                     'mate', (140 + pos_x - string_len / 1.5, 140 + pos_y))
-            elif the_relationship.cat_to.mate != None and the_relationship.cat_to.mate != '':
+            elif the_relationship.cat_to.mate is not None and the_relationship.cat_to.mate != '':
                 verdana_small.text(
                     'has a mate',
                     (140 + pos_x - string_len / 1.5, 140 + pos_y))

--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -23,7 +23,7 @@ class TestCreationAge(unittest.TestCase):
         test_cat = Cat(moons=48)
         self.assertEqual(test_cat.age,"adult")
 
-    def test_adult(self):
+    def test_senior_adult(self):
         test_cat = Cat(moons=96)
         self.assertEqual(test_cat.age,"senior adult")
 


### PR DESCRIPTION
Tested the exp. branch with a few linters & tried to apply a few of the more straightforward fixes/optimizations, should've maybe split this up into multiple commits & pulls... :"3

This doesn't apply any style-related changes as to not exacerbate possible merge conflicts with other forks.
 
(+0.18 with pylint)
![woo](https://user-images.githubusercontent.com/69427753/199608267-8a5b69b2-2a37-4479-b5c1-2706f89d0934.png)

Addition:
 - Added python3 shebang to main.py

Fixes:
 - Fixed 'NOTAIL' not causing 'HALFTAIL' to be set to None because `cat.specialty == None` was used instead of an assignment.
 - Renamed second test_adult function to test_senior_adult to avoid redefinition

Pylint recommendations:
 - Removed unused ujson import from `clangen/scripts/conditions.py`
 - Removed object inherits, which are already implictly inherited in Python 3. Presumably this is a leftover from Python 2? (pylint useless-object-inheritance / R0205)
 - Replaced instances of ``x == True`` with just `x` and `x == False` with `not x` (pylint singleton-comparison / C0121)
 - Replaced instances of equality operators with identity operators where applicable, like `x == None` --> `x is None`. (pylint singleton-comparison / C0121)