### PR TITLE
bugfixes: backstories changing and loner name events not being correct

### DIFF
--- a/scripts/events.py
+++ b/scripts/events.py
@@ -692,13 +692,13 @@ class Events(object):
                     f'{name} finds a loner who joins the clan',
                     f'A loner says that they are interested in clan life and joins the clan'
                 ]
-                if str(loner_name) in [names.loner_names]:
+                if loner_name.suffix is not None:
                     success_text = [
-                        f'{str(loner_name)} decides to keep their name'
+                        f'The loner decides to take on a slightly more clan-like name, and is now called {str(loner_name)}'
                     ]
                 else:
                     success_text = [
-                        f'The loner decides to take on a slightly more clan-like name, and is now called {str(loner_name)}'
+                        f'{str(loner_name)} decides to keep their name'
                     ]
                 game.cur_events_list.append(choice(loner_text))
                 game.cur_events_list.append(choice(success_text))

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -152,8 +152,8 @@ def backstory_text(cat, backstory):
         if cat.status == 'medicine cat':
             bs_display = 'disgraced medicine cat'
         elif cat.status in ['warrior', 'elder']:
-            bs_display = choice(['disgraced leader', 'disgraced deputy'])
-            bs_display = bs_display
+            bs_display_choice = choice(['disgraced leader', 'disgraced deputy'])
+            bs_display = bs_display_choice
     elif bs_display == 'retired_leader':
         bs_display = 'retired leader'
     elif bs_display == 'refugee':


### PR DESCRIPTION
- fixed the bug where disgraced leader and disgraced deputy kept switching
- fixed the loner event so that it actually shows the correct event when they change their name or don't