### PR TITLE
Bugfix: Deputy Promotion button , +1 button, ect

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -760,14 +760,19 @@ class Cat():
                     new_mentor.former_apprentices.remove(self)
         else:
             self.mentor = None
+
         # Move from old mentor's apps to former apps
         if old_mentor is not None and old_mentor != self.mentor:
-            if self in old_mentor.apprentice:
-                old_mentor.apprentice.remove(self)
-            if self not in old_mentor.former_apprentices:
-                old_mentor.former_apprentices.append(self)
-            if old_mentor not in self.former_mentor:
-                self.former_mentor.append(old_mentor)
+            if self.moons != 6:
+                if self in old_mentor.apprentice:
+                    old_mentor.apprentice.remove(self)
+                if self not in old_mentor.former_apprentices:
+                    old_mentor.former_apprentices.append(self)
+                if old_mentor not in self.former_mentor:
+                    self.former_mentor.append(old_mentor)
+            else:
+                if self in old_mentor.apprentice:
+                    old_mentor.apprentice.remove(self)
 
     def update_mentor(self, new_mentor=None):
         if new_mentor is None:
@@ -801,7 +806,7 @@ class Cat():
         else:
             self.mentor = None
         # Move from old mentor's apps to former apps
-        if self.status == 'warrior' or self.status == 'medicine cat':
+        if self.status == 'warrior':
             self.former_mentor.append(old_mentor)
             self.mentor = None
             if old_mentor is not None:
@@ -811,12 +816,16 @@ class Cat():
                     old_mentor.former_apprentices.append(self)
 
         if old_mentor is not None and old_mentor != self.mentor:
-            if self in old_mentor.apprentice:
-                old_mentor.apprentice.remove(self)
-            if self not in old_mentor.former_apprentices:
-                old_mentor.former_apprentices.append(self)
-            if old_mentor not in self.former_mentor:
-                self.former_mentor.append(old_mentor)
+            if self.moons != 6:
+                if self in old_mentor.apprentice:
+                    old_mentor.apprentice.remove(self)
+                if self not in old_mentor.former_apprentices:
+                    old_mentor.former_apprentices.append(self)
+                if old_mentor not in self.former_mentor:
+                    self.former_mentor.append(old_mentor)
+            else:
+                if self in old_mentor.apprentice:
+                    old_mentor.apprentice.remove(self)
 
 
 # ---------------------------------------------------------------------------- #

--- a/scripts/screens/base_screens.py
+++ b/scripts/screens/base_screens.py
@@ -201,7 +201,8 @@ def draw_next_prev_cat_buttons(the_cat):
                                   size=(153, 30),
                                   hotkey=[21],
                                   show_details=False,
-                                  chosen_cat=None
+                                  chosen_cat=None,
+                                  mate=None
                                   )
     else:
         buttons.draw_image_button((622, 25),
@@ -220,7 +221,8 @@ def draw_next_prev_cat_buttons(the_cat):
                                   cat=previous_cat,
                                   size=(153, 30),
                                   hotkey=[23],
-                                  show_details=False
+                                  show_details=False,
+                                  mate=None
                                   )
     else:
         buttons.draw_image_button((25, 25),

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -731,7 +731,7 @@ class ProfileScreen(Screens):
             # promote a cat to deputy if no deputy is alive
             if the_cat.status in [
                 'warrior'
-            ] and not the_cat.dead and not the_cat.exiled and game.clan.deputy is None:
+            ] and not the_cat.dead and not the_cat.exiled and game.clan.deputy is None or game.clan.deputy == 0 or game.clan.deputy.exiled or game.clan.deputy.dead:
                 buttons.draw_image_button((226, 486),
                                           button_name='promote_deputy',
                                           text='promote to deputy',

--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -481,18 +481,9 @@ class PatrolScreen(Screens):
         # SHOW APPRENTICE SPRITE AND BUTTON
         if chosen_cat.apprentice != []:
 
-            x = 0
-            if len(chosen_cat.apprentice) == 1:
-                x = 0
-            elif chosen_cat.apprentice[0] in game.switches['current_patrol'] \
-                    and chosen_cat.apprentice[1] not in game.switches['current_patrol']:
-                x = 1
-            elif chosen_cat.apprentice[1] in game.switches['current_patrol'] \
-                    and chosen_cat.apprentice[2] not in game.switches['current_patrol']:
-                x = 3
             screen.blit(PatrolScreen.app_frame, (495, 190))
-            draw_big(chosen_cat.apprentice[x], (550, 200))
-            if chosen_cat.apprentice[x] in able_cats:
+            draw_big(chosen_cat.apprentice[0], (550, 200))
+            if chosen_cat.apprentice[0] in able_cats:
                 buttons.draw_image_button(
                     (548, 356),
                     button_name='patrol_select',
@@ -504,12 +495,12 @@ class PatrolScreen(Screens):
                     (548, 356),
                     button_name='patrol_select',
                     size=(104, 26),
-                    cat=chosen_cat.apprentice[x],
+                    cat=chosen_cat.apprentice[0],
                     available=False
                     )
-            name = str(chosen_cat.apprentice[x].name)  # get name
+            name = str(chosen_cat.apprentice[0].name)  # get name
             if 10 <= len(name) >= 12:  # check name length
-                short_name = str(chosen_cat.apprentice[x].name)[0:9]
+                short_name = str(chosen_cat.apprentice[0].name)[0:9]
                 name = short_name + '...'
             verdana.text(str(name),
                               ('center', 310),

--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -243,7 +243,7 @@ class PatrolScreen(Screens):
         #                         add 1 random cat to patrol                           #
         # ---------------------------------------------------------------------------- #
         # DRAW ADD 1 RANDOM CAT BUTTON IF PATROL STILL HAS SPACE
-        if len(game.switches['current_patrol']) <= 5 and len(able_cats) > 1:
+        if len(game.switches['current_patrol']) <= 5 and len(able_cats) >= 1:
             buttons.draw_button((363, 495),
                                 image='buttons/add_1',
                                 text='add 1',

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -450,6 +450,7 @@ class ChooseMateScreen(Screens):
         game.switches['choosing_mate'] = True
 
         draw_choosing_bg(494, 'mate')
+
         draw_next_prev_cat_buttons(the_cat)
 
         y_value = 30

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -614,7 +614,6 @@ class ChooseMateScreen(Screens):
             relation = relation[0]
         else:
             Cat.all_cats.get(arg2.ID).create_new_relationships()
-
         romantic_love = relation.romantic_love
 
         if 10 <= romantic_love <= 30:

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -355,14 +355,6 @@ class ViewChildrenScreen(Screens):
         if siblings is False:
             verdana.text('This cat has no siblings.', (380, 200))
 
-        if the_cat.exiled:
-            buttons.draw_button(('center', 670),
-                            text='Back',
-                            cur_screen='outside profile screen')
-        else:
-            buttons.draw_button(('center', 670),
-                            text='Back',
-                            cur_screen='profile screen')
         pos_x = 0
         pos_y = 60
         # SHOW MATE
@@ -423,22 +415,23 @@ class ViewChildrenScreen(Screens):
         if kittens is False:
             verdana.text('This cat has never had offspring.', (350, 480))
 
-        buttons.draw_image_button((25, 645),
-                                  button_name='back',
-                                  text='Back',
-                                  size=(105, 30),
-                                  cur_screen='profile screen',
-                                  chosen_cat=None,
-                                  show_details=False)
-
         if the_cat.exiled:
-            buttons.draw_button(('center', 670),
-                                text='Back',
-                                cur_screen='outside profile screen')
+            buttons.draw_image_button((25, 645),
+                                      button_name='back',
+                                      text='Back',
+                                      size=(105, 30),
+                                      cur_screen='outside profile screen',
+                                      chosen_cat=None,
+                                      show_details=False)
         else:
-            buttons.draw_button(('center', 670),
-                                text='Back',
-                                cur_screen='profile screen')
+            buttons.draw_image_button((25, 645),
+                                      button_name='back',
+                                      text='Back',
+                                      size=(105, 30),
+                                      cur_screen='profile screen',
+                                      chosen_cat=None,
+                                      show_details=False)
+
     def screen_switches(self):
         cat_profiles()
 


### PR DESCRIPTION
Bugfix: adding additional checks to make certain the button is available when no deputy is present

Bugfix: fixed the +1 button disappearing if only one able cat was left

Bugfix: If you selected a cat on the Choose Mates screen and then hit the next/prev cat buttons, the selected cat would not be reset.  This caused a crash if you continued hitting next/prev till you reached the Choose Mate screen of the selected cat, causing it to try and show the cat as it's own potential mate.

Bugfix:  If you switched an 6 moon apprentice from warrior app to med app then they would still be listed on the Former App list of their old mentor.

Less a bugfix, and more a temporary solution:  The patrol screen displays and allows you to directly select a mentor's apprentice.  However, it only displays the oldest apprentice, if the mentor has more than one apprentice then it does not display the newer apprentices.  I had tried to implement a way for the newer apprentice to display one the older apprentice was added to the patrol, but this was causing crashes intermittently.  I had previously attempted to add arrows that let you switch between the apprentices, but I wasn't able to get that to work at the time.  For now I have just removed it entirely, the patrol screen will only display a mentor's oldest apprentice.  I invite someone else to try and find a solution for this as my attempts were lackluster.

Visual Bugfix: The old back button was displaying on the Family Screen along with the new one.  I removed the old button.