### PR TITLE
perf: Quick image optimizations

### DIFF
--- a/scripts/game_structure/buttons.py
+++ b/scripts/game_structure/buttons.py
@@ -1,7 +1,7 @@
 from .text import *
 from .load_cat import *
 from .game_essentials import *
-
+from . import image_cache
 from scripts.cat.cats import Cat
 
 
@@ -50,13 +50,13 @@ class Button():
             image_path = f'resources/images/buttons/{button_name}.png'
         else: 
             image_path = f'resources/images/buttons/{button_name}_unavailable.png'
-        image = pygame.image.load(image_path).convert_alpha()
+        image = image_cache.load_image(image_path).convert_alpha()
         button = pygame.transform.scale(image, size)
         collided = self.used_screen.blit(button, pos)
         if available and collided.collidepoint(self.used_mouse.pos):
             is_clickable = True
             image_path = f'resources/images/buttons/{button_name}_hover.png'
-            image = pygame.image.load(image_path).convert_alpha()
+            image = image_cache.load_image(image_path).convert_alpha()
             button = pygame.transform.scale(image, size)
         self.used_screen.blit(button, pos)
         if game.clicked and is_clickable:
@@ -150,7 +150,7 @@ class Button():
                      self.font.size + self.padding[1] * 2))
 
         elif dynamic_image:
-            new_button = pygame.image.load(f"{image}.png").convert_alpha()
+            new_button = image_cache.load_image(f"{image}.png").convert_alpha()
         else:
             new_button = image
         new_pos = list(pos)
@@ -180,7 +180,7 @@ class Button():
                 new_button.fill(colour)
                 self.font.text(text, (self.padding[0], 0), new_button)
         elif dynamic_image:
-            new_button = pygame.image.load(f"{image}.png").convert_alpha()
+            new_button = image_cache.load_image(f"{image}.png").convert_alpha()
         self.used_screen.blit(new_button, new_pos)
         if game.clicked and clickable:
             if apprentice is not None:

--- a/scripts/game_structure/image_cache.py
+++ b/scripts/game_structure/image_cache.py
@@ -1,0 +1,11 @@
+import pygame
+
+_images = {}
+def load_image(path):
+    """
+    If not in the cache already, loads the image from path as a surface.
+    Otherwise, the image is retrieved from the cache.
+    """
+    if path not in _images:
+        _images[path] = pygame.image.load(path)
+    return _images[path]

--- a/scripts/screens/base_screens.py
+++ b/scripts/screens/base_screens.py
@@ -4,6 +4,7 @@ from scripts.game_structure.buttons import Button, buttons
 from scripts.game_structure.game_essentials import *
 from scripts.clan import map_available
 from scripts.game_structure.text import *
+import scripts.game_structure.image_cache as image_cache
 
 
 class Screens():
@@ -105,7 +106,7 @@ def draw_menu_buttons():
 # ---------------------------------------------------------------------------- #
 def draw_clan_name():
     clan_name_bg = pygame.transform.scale(
-        pygame.image.load("resources/images/clan_name_bg.png").convert_alpha(), (180, 35))
+        image_cache.load_image("resources/images/clan_name_bg.png").convert_alpha(), (180, 35))
     screen.blit(clan_name_bg, (310, 25))
 
     verdana_big_light.text(f'{game.clan.name}Clan', ('center', 32))

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -7,6 +7,7 @@ from scripts.game_structure.text import *
 from scripts.game_structure.buttons import buttons
 from scripts.cat.cats import Cat
 from scripts.cat.pelts import collars, wild_accessories
+import scripts.game_structure.image_cache as image_cache
 
 
 # ---------------------------------------------------------------------------- #
@@ -23,7 +24,7 @@ def draw_text_bar():
         verdana.text(game.switches['naming_text'], (315, 204))
 
     text_input_frame = pygame.transform.scale(
-        pygame.image.load("resources/images/text_input_frame.png").convert_alpha(), (216, 40))
+        image_cache.load_image("resources/images/text_input_frame.png").convert_alpha(), (216, 40))
     screen.blit(text_input_frame, (294, 194))
 
 

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -226,7 +226,7 @@ def backstory_text(cat):
 class ProfileScreen(Screens):
 
     # UI Images
-    backstory_tab = pygame.image.load("resources/images/backstory_bg.png")
+    backstory_tab = pygame.image.load("resources/images/backstory_bg.png").convert_alpha()
 
     def on_use(self):
         # use this variable to point to the cat object in question

--- a/scripts/screens/clan_creation_screens.py
+++ b/scripts/screens/clan_creation_screens.py
@@ -10,6 +10,7 @@ from scripts.clan import Clan, map_available
 from scripts.cat.cats import create_example_cats
 from scripts.cat.names import names
 from scripts.cat.sprites import tiles
+import scripts.game_structure.image_cache as image_cache
 #from scripts.world import World, save_map
 map_available = False
 
@@ -60,7 +61,7 @@ class MakeClanScreen(Screens):
         #                                    layout                                    #
         # ---------------------------------------------------------------------------- #
         draw_main_menu(self)
-        text_box = pygame.image.load(
+        text_box = image_cache.load_image(
             'resources/images/game_mode_text_box.png').convert_alpha()
         screen.blit(text_box, (325, 130))
 
@@ -599,27 +600,27 @@ class MakeClanScreen(Screens):
                                   )
 
         if 0 == len(game.switches['members']):
-            clan_none_img = pygame.image.load(
+            clan_none_img = image_cache.load_image(
                 'resources/images/pick_clan_screen/clan_none_light.png').convert_alpha()
             screen.blit(clan_none_img, (0, 414))
         elif 1 == len(game.switches['members']):
-            clan_one_img = pygame.image.load(
+            clan_one_img = image_cache.load_image(
                 'resources/images/pick_clan_screen/clan_one_light.png').convert_alpha()
             screen.blit(clan_one_img, (0, 414))
         elif 2 == len(game.switches['members']):
-            clan_two_img = pygame.image.load(
+            clan_two_img = image_cache.load_image(
                 'resources/images/pick_clan_screen/clan_two_light.png').convert_alpha()
             screen.blit(clan_two_img, (0, 414))
         elif 3 == len(game.switches['members']):
-            clan_three_img = pygame.image.load(
+            clan_three_img = image_cache.load_image(
                 'resources/images/pick_clan_screen/clan_three_light.png').convert_alpha()
             screen.blit(clan_three_img, (0, 414))
         elif 3 < len(game.switches['members']) < 7:
-            clan_four_img = pygame.image.load(
+            clan_four_img = image_cache.load_image(
                 'resources/images/pick_clan_screen/clan_four_light.png').convert_alpha()
             screen.blit(clan_four_img, (0, 414))
         elif 7 == len(game.switches['members']):
-            clan_full_img = pygame.image.load(
+            clan_full_img = image_cache.load_image(
                 'resources/images/pick_clan_screen/clan_full_light.png').convert_alpha()
             screen.blit(clan_full_img, (0, 414))
 
@@ -1027,9 +1028,9 @@ class MakeClanScreen(Screens):
 
     def change_camp_art(self, arg0, arg1):
         self.camp1 = pygame.transform.scale(
-            pygame.image.load(arg0).convert(), (450, 400))
+            image_cache.load_image(arg0).convert(), (450, 400))
         self.camp2 = pygame.transform.scale(
-            pygame.image.load(arg1).convert(), (450, 400))
+            image_cache.load_image(arg1).convert(), (450, 400))
 
 
     def on_use(self):

--- a/scripts/screens/event_screens.py
+++ b/scripts/screens/event_screens.py
@@ -191,9 +191,9 @@ class EventsScreen(Screens):
 
 class PatrolEventScreen(Screens):
 
-    event_bg = pygame.image.load("resources/images/patrol_event_frame.png")
-    info_bg = pygame.image.load("resources/images/patrol_info.png")
-    image_frame = pygame.image.load("resources/images/patrol_sprite_frame.png")
+    event_bg = pygame.image.load("resources/images/patrol_event_frame.png").convert_alpha()
+    info_bg = pygame.image.load("resources/images/patrol_info.png").convert_alpha()
+    image_frame = pygame.image.load("resources/images/patrol_sprite_frame.png").convert_alpha()
 
     def get_list_text(self, patrol_list):
         if not patrol_list:

--- a/scripts/screens/organizational_screens.py
+++ b/scripts/screens/organizational_screens.py
@@ -93,7 +93,7 @@ class StartScreen(Screens):
 
 class SwitchClanScreen(Screens):
 
-    saves_frame = pygame.image.load("resources/images/clan_saves_frame.png")
+    saves_frame = pygame.image.load("resources/images/clan_saves_frame.png").convert_alpha()
 
     def on_use(self):
 

--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -10,11 +10,11 @@ from scripts.cat.cats import Cat
 
 class PatrolScreen(Screens):
 
-    able_box = pygame.image.load("resources/images/patrol_able_cats.png")
-    patrol_box = pygame.image.load("resources/images/patrol_cats.png")
-    cat_frame = pygame.image.load("resources/images/patrol_cat_frame.png")
-    app_frame = pygame.image.load("resources/images/patrol_app_frame.png")
-    mate_frame = pygame.image.load("resources/images/patrol_mate_frame.png")
+    able_box = pygame.image.load("resources/images/patrol_able_cats.png").convert_alpha()
+    patrol_box = pygame.image.load("resources/images/patrol_cats.png").convert_alpha()
+    cat_frame = pygame.image.load("resources/images/patrol_cat_frame.png").convert_alpha()
+    app_frame = pygame.image.load("resources/images/patrol_app_frame.png").convert_alpha()
+    mate_frame = pygame.image.load("resources/images/patrol_mate_frame.png").convert_alpha()
 
     def on_use(self):
         # USER INTERFACE

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -260,8 +260,8 @@ def show_mentor_cat_info(arg0, arg1, arg2):
 
 
 class ViewChildrenScreen(Screens):
-    parents = pygame.image.load("resources/images/family_parents.png")
-    mate = pygame.image.load("resources/images/family_mate.png")
+    parents = pygame.image.load("resources/images/family_parents.png").convert_alpha()
+    mate = pygame.image.load("resources/images/family_mate.png").convert_alpha()
 
     def on_use(self):
         the_cat = Cat.all_cats[game.switches['cat']]

--- a/scripts/screens/relation_screens.py
+++ b/scripts/screens/relation_screens.py
@@ -6,12 +6,13 @@ from scripts.utility import draw_large, draw, update_sprite, get_personality_com
 from scripts.game_structure.buttons import buttons
 from scripts.game_structure.text import *
 from scripts.cat.cats import Cat
+import scripts.game_structure.image_cache as image_cache
 
 
 def draw_choosing_bg(arg0, arg1):
-    list_frame = pygame.image.load("resources/images/choosing_frame.png").convert_alpha()
-    cat1_frame_arg1 = pygame.image.load(f"resources/images/choosing_cat1_frame_{arg1}.png").convert_alpha()
-    cat2_frame_arg1 = pygame.image.load(f"resources/images/choosing_cat2_frame_{arg1}.png").convert_alpha()
+    list_frame = image_cache.load_image("resources/images/choosing_frame.png").convert_alpha()
+    cat1_frame_arg1 = image_cache.load_image(f"resources/images/choosing_cat1_frame_{arg1}.png").convert_alpha()
+    cat2_frame_arg1 = image_cache.load_image(f"resources/images/choosing_cat2_frame_{arg1}.png").convert_alpha()
 
     y_value = 113
 
@@ -254,7 +255,7 @@ def show_mentor_cat_info(arg0, arg1, arg2):
                                 x_limit=arg1 + 100
                                 )
 
-    mentor_icon = pygame.image.load("resources/images/mentor.png")
+    mentor_icon = image_cache.load_image("resources/images/mentor.png")
     screen.blit(mentor_icon, (315, 160))
 
 
@@ -571,9 +572,9 @@ class ChooseMateScreen(Screens):
 
 
     def heart_status(self, the_cat, mate):
-        q_heart = pygame.image.load("resources/images/heart_maybe.png").convert_alpha()
-        heart = pygame.image.load("resources/images/heart_mates.png").convert_alpha()
-        b_heart = pygame.image.load("resources/images/heart_breakup.png").convert_alpha()
+        q_heart = image_cache.load_image("resources/images/heart_maybe.png").convert_alpha()
+        heart = image_cache.load_image("resources/images/heart_mates.png").convert_alpha()
+        b_heart = image_cache.load_image("resources/images/heart_breakup.png").convert_alpha()
 
         x_value = 300
         y_value = 188
@@ -591,10 +592,10 @@ class ChooseMateScreen(Screens):
         # incompatible = pygame.image.load("resources/images/pers_incompatible.png")
         # neutral = pygame.image.load("resources/images/pers_neutral.png")
 
-        compatible = pygame.image.load("resources/images/line_compatible.png").convert_alpha()
-        incompatible = pygame.image.load("resources/images/line_incompatible.png").convert_alpha()
-        neutral = pygame.image.load("resources/images/line_neutral.png").convert_alpha()
-        s_heart = pygame.image.load("resources/images/heart_big.png").convert_alpha()
+        compatible = image_cache.load_image("resources/images/line_compatible.png").convert_alpha()
+        incompatible = image_cache.load_image("resources/images/line_incompatible.png").convert_alpha()
+        neutral = image_cache.load_image("resources/images/line_neutral.png").convert_alpha()
+        s_heart = image_cache.load_image("resources/images/heart_big.png").convert_alpha()
         x_value = 300
         y_value = 190
 
@@ -772,28 +773,28 @@ def show_mate_cat_info(arg0, arg1, arg2):
 class RelationshipScreen(Screens):
     bool = {True: 'on', False: 'off', None: 'None'}
 
-    search_bar = pygame.image.load("resources/images/relationship_search.png").convert_alpha()
-    details_frame = pygame.image.load("resources/images/relationship_details_frame.png").convert_alpha()
-    toggle_frame = pygame.image.load("resources/images/relationship_toggle_frame.png").convert_alpha()
-    list_frame = pygame.image.load("resources/images/relationship_list_frame.png").convert_alpha()
+    search_bar = image_cache.load_image("resources/images/relationship_search.png").convert_alpha()
+    details_frame = image_cache.load_image("resources/images/relationship_details_frame.png").convert_alpha()
+    toggle_frame = image_cache.load_image("resources/images/relationship_toggle_frame.png").convert_alpha()
+    list_frame = image_cache.load_image("resources/images/relationship_list_frame.png").convert_alpha()
 
-    female_icon = pygame.image.load("resources/images/female_big.png").convert_alpha()
-    male_icon = pygame.image.load("resources/images/male_big.png").convert_alpha()
-    nonbi_icon = pygame.image.load("resources/images/nonbi_big.png").convert_alpha()
-    transfem_icon = pygame.image.load("resources/images/transfem_big.png").convert_alpha()
-    transmasc_icon = pygame.image.load("resources/images/transmasc_big.png").convert_alpha()
+    female_icon = image_cache.load_image("resources/images/female_big.png").convert_alpha()
+    male_icon = image_cache.load_image("resources/images/male_big.png").convert_alpha()
+    nonbi_icon = image_cache.load_image("resources/images/nonbi_big.png").convert_alpha()
+    transfem_icon = image_cache.load_image("resources/images/transfem_big.png").convert_alpha()
+    transmasc_icon = image_cache.load_image("resources/images/transmasc_big.png").convert_alpha()
 
-    female_icon_small = pygame.transform.scale(pygame.image.load("resources/images/female_big.png").convert_alpha(), (18, 18))
-    male_icon_small = pygame.transform.scale(pygame.image.load("resources/images/male_big.png").convert_alpha(), (18, 18))
-    nonbi_icon_small = pygame.transform.scale(pygame.image.load("resources/images/nonbi_big.png").convert_alpha(), (18, 18))
-    transfem_icon_small = pygame.transform.scale(pygame.image.load("resources/images/transfem_big.png").convert_alpha(), (18, 18))
-    transmasc_icon_small = pygame.transform.scale(pygame.image.load("resources/images/transmasc_big.png").convert_alpha(), (18, 18))
+    female_icon_small = pygame.transform.scale(image_cache.load_image("resources/images/female_big.png").convert_alpha(), (18, 18))
+    male_icon_small = pygame.transform.scale(image_cache.load_image("resources/images/male_big.png").convert_alpha(), (18, 18))
+    nonbi_icon_small = pygame.transform.scale(image_cache.load_image("resources/images/nonbi_big.png").convert_alpha(), (18, 18))
+    transfem_icon_small = pygame.transform.scale(image_cache.load_image("resources/images/transfem_big.png").convert_alpha(), (18, 18))
+    transmasc_icon_small = pygame.transform.scale(image_cache.load_image("resources/images/transmasc_big.png").convert_alpha(), (18, 18))
 
-    mate_icon = pygame.image.load("resources/images/heart_big.png").convert_alpha()
-    family_icon = pygame.image.load("resources/images/dot_big.png").convert_alpha()
+    mate_icon = image_cache.load_image("resources/images/heart_big.png").convert_alpha()
+    family_icon = image_cache.load_image("resources/images/dot_big.png").convert_alpha()
 
-    mate_icon_small = pygame.transform.scale(pygame.image.load("resources/images/heart_big.png").convert_alpha(), (11, 10))
-    family_icon_small = pygame.transform.scale(pygame.image.load("resources/images/dot_big.png").convert_alpha(), (9, 9))
+    mate_icon_small = pygame.transform.scale(image_cache.load_image("resources/images/heart_big.png").convert_alpha(), (11, 10))
+    family_icon_small = pygame.transform.scale(image_cache.load_image("resources/images/dot_big.png").convert_alpha(), (9, 9))
 
     def on_use(self):
         # use this variable to point to the cat object in question
@@ -1325,11 +1326,11 @@ class RelationshipScreen(Screens):
 
     def draw_bar(self, value, pos_x, pos_y):
         # Loading Bar and variables
-        bar_bg = pygame.image.load(
+        bar_bg = image_cache.load_image(
             "resources/images/relations_border.png").convert_alpha()
-        bar_bg_dark = pygame.image.load(
+        bar_bg_dark = image_cache.load_image(
             "resources/images/relations_border_dark.png").convert_alpha()
-        original_bar = pygame.image.load(
+        original_bar = image_cache.load_image(
             "resources/images/relation_bar.png").convert_alpha()
 
         bg_rect = bar_bg.get_rect(midleft=(pos_x, pos_y))

--- a/scripts/screens/world_screens.py
+++ b/scripts/screens/world_screens.py
@@ -7,13 +7,14 @@ from scripts.game_structure.text import *
 from scripts.game_structure.buttons import buttons
 from scripts.cat.cats import Cat
 from scripts.cat.sprites import tiles
+import scripts.game_structure.image_cache as image_cache
 #from scripts.world import load_map
 
 class OutsideClanScreen(Screens):
 
     def on_use(self):
         clan_name_bg = pygame.transform.scale(
-            pygame.image.load("resources/images/outside_clan_bg.png").convert_alpha(), (242, 35))
+            image_cache.load_image("resources/images/outside_clan_bg.png").convert_alpha(), (242, 35))
         screen.blit(clan_name_bg, (279, 25))
         verdana_big_light.text('Cats Outside The Clan', ('center', 32))
 
@@ -25,7 +26,7 @@ class OutsideClanScreen(Screens):
 
         search_text = game.switches['search_text']
         search_bar = pygame.transform.scale(
-            pygame.image.load("resources/images/search_bar.png").convert_alpha(), (228, 34))
+            image_cache.load_image("resources/images/search_bar.png").convert_alpha(), (228, 34))
         screen.blit(search_bar, (452, 135))
         verdana_black.text(game.switches['search_text'], (530, 142))
 


### PR DESCRIPTION
A few image optimizations to go with the UI update: 
* Creates a new module `image_cache` that implements a really simple dictionary caching function for loading images, and calls it on images that are loaded every frame. My justification for making it a function in a module rather than a class is that I don't think there's a use for multiple image caches in this project so having it easily imported makes it easier to use.
* Runs `convert_alpha()` on some surfaces that didn't have it. This just makes blitting the surfaces a bit faster.