### PR TITLE
Bugfix: patrol screen mentor crash

### DIFF
--- a/scripts/screens/patrol_screens.py
+++ b/scripts/screens/patrol_screens.py
@@ -488,7 +488,7 @@ class PatrolScreen(Screens):
                     (548, 356),
                     button_name='patrol_select',
                     size=(104, 26),
-                    cat=chosen_cat.apprentice[x]
+                    cat=chosen_cat.apprentice[0]
                     )
             else:
                 buttons.draw_image_button(


### PR DESCRIPTION
clicking on a cat with an apprentice (while viewing the patrol screen) would crash the game,  it's now fixed