### PR TITLE
Bugfix: Deathberry event, Trans button

### DIFF
--- a/scripts/patrol.py
+++ b/scripts/patrol.py
@@ -259,7 +259,7 @@ class Patrol():
                     10,
                     win_skills=['very smart', 'extremely smart']),
                 PatrolEvent(
-                    116,
+                    117,
                     'While helping gathering herbs, r_c stumbles upon a bush of red berries',
                     'Yum! r_c recognizes them as strawberries and shares the tasty treat with the patrol',
                     'The patrol scolds r_c for wasting time munching on berries',
@@ -720,7 +720,7 @@ class Patrol():
 
     def handle_deaths(self):
         if self.patrol_event.patrol_id in [
-                108, 113, 114, 120, 141, 250, 305, 307, 802, 803, 804
+                108, 113, 114, 120, 141, 250, 305, 307, 802, 803, 804, 116
         ]:
             if self.patrol_random_cat.status == 'leader':
                 if self.patrol_event.patrol_id in [108, 113]:

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -907,7 +907,7 @@ class ProfileScreen(Screens):
                                       )
 
             # change cat to trans male
-            if the_cat.genderalign == "female":
+            if the_cat.gender == "female" and the_cat.genderalign in ['male', 'female']:
                 buttons.draw_image_button((402, 486),
                                           button_name='change_trans_male',
                                           text='change to trans male',
@@ -918,7 +918,7 @@ class ProfileScreen(Screens):
                     the_cat.genderalign = 'trans male'
 
             # change cat to trans female
-            elif the_cat.genderalign == "male":
+            elif the_cat.gender == "male" and the_cat.genderalign in ['male', 'female']:
                 buttons.draw_image_button((402, 486),
                                           button_name='change_trans_female',
                                           text='change to trans female',


### PR DESCRIPTION
Deathberry event ID wasn't in the list of patrols that kill, it was also the same as the ID for the Strawberry event (a variant of the deathberry.) ID is now in the right spot.

Trans button was showing incorrect gender if the cat's gender was switching using specify gender screen (so you could set a female cat as 'male' and then the trans button would be 'switch to trans female')