### PR TITLE
Bugfix: Grammar and Trait Choosing Crash

### DIFF
--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -431,6 +431,7 @@ class Cat():
                             else:
                                 print(self.name, 'TRAIT TYPE from mentor: Reserved', 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:',
                                       chance)
+                                break
             else:
                 self.mentor_influence.append('None')
                 print(self.name, 'NEW TRAIT TYPE: No change', chance)
@@ -606,6 +607,7 @@ class Cat():
                                 self.skill = choice(possible_skill)
                                 self.mentor_influence.append(self.skill)
                                 print('skill from mentor')
+                                break
                     else:
                         self.skill = choice(self.med_skills)
                         self.mentor_influence.append('None')
@@ -627,6 +629,7 @@ class Cat():
                                 self.skill = choice(possible_skill)
                                 self.mentor_influence.append(self.skill)
                                 print('skill from mentor. chance:', chance)
+                                break
 
                     else:
                         self.skill = choice(self.skills)

--- a/scripts/cat/cats.py
+++ b/scripts/cat/cats.py
@@ -364,9 +364,11 @@ class Cat():
                         if chosen_trait in self.kit_traits:
                             self.trait = choice(self.traits)
                             print(self.name, 'NEW TRAIT TYPE: Random - CHANCE', chance)
+                            break
                         else:
                             self.trait = chosen_trait
                             print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
+                            break
         elif self.moons == 12:
             chance = randint(0, 9) + int(self.patrol_with_mentor)  # chance for cat to gain new trait or keep old
             if chance == 0:
@@ -380,13 +382,15 @@ class Cat():
                         possible_trait = self.personality_groups.get(x)
                         chosen_trait = choice(possible_trait)
                         if chosen_trait in self.kit_traits:
-                            self.trait = choice(self.traits)
+                            self.trait = self.trait
                             self.mentor_influence.append('None')
-                            print(self.name, 'NEW TRAIT TYPE: Random - CHANCE', chance)
+                            print(self.name, 'NEW TRAIT TYPE: No change - CHANCE', chance)
+                            break
                         else:
                             self.trait = chosen_trait
                             self.mentor_influence.append('None')
                             print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
+                            break
             elif chance >= 7:
                 possible_groups = ['Outgoing', 'Benevolent', 'Abrasive', 'Reserved']
                 for x in possible_groups:
@@ -398,26 +402,35 @@ class Cat():
                         else:
                             mentor = self.former_mentor[0]
                     else:
+                        self.mentor_influence.append('None')
                         print(self.name, 'NEW TRAIT TYPE: No change', chance)
                         break
                     if mentor.trait in self.personality_groups[x]:
                         possible_trait = self.personality_groups.get(x)
+
                         if x == 'Abrasive' and chance >= 12:
                             possible_trait = self.personality_groups.get('Reserved')
                             self.mentor_influence.append('Reserved')
-                            print(self.name, 'TRAIT TYPE from mentor:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:',
-                                  chance)
                         chosen_trait = choice(possible_trait)
+
                         if chosen_trait in self.kit_traits:
                             self.trait = choice(self.traits)
+                            if self.mentor_influence[0] == 'Reserved':
+                                self.mentor_influence.pop(0)
                             self.mentor_influence.append('None')
                             print(self.name, 'NEW TRAIT TYPE: Random - CHANCE', chance)
+                            break
 
                         else:
                             self.trait = chosen_trait
-                            self.mentor_influence.append(x)
-                            print(self.name, 'TRAIT TYPE from mentor:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:',
-                                  chance)
+                            if 'Reserved' not in self.mentor_influence:
+                                self.mentor_influence.append(x)
+                                print(self.name, 'TRAIT TYPE from mentor:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:',
+                                      chance)
+                                break
+                            else:
+                                print(self.name, 'TRAIT TYPE from mentor: Reserved', 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:',
+                                      chance)
             else:
                 self.mentor_influence.append('None')
                 print(self.name, 'NEW TRAIT TYPE: No change', chance)
@@ -437,9 +450,11 @@ class Cat():
                             self.trait = choice(self.traits)
                             print(self.name, 'trait type chosen was kit trait -', self.trait,
                                   'chosen randomly instead')
+                            break
                         else:
                             self.trait = chosen_trait
                             print(self.name, 'TRAIT TYPE:', x, 'NEW TRAIT PICKED:', chosen_trait, 'CHANCE:', chance)
+                            break
             else:
                 print(self.name, 'NEW TRAIT TYPE: No change', chance)
 

--- a/scripts/screens/cat_screens.py
+++ b/scripts/screens/cat_screens.py
@@ -618,18 +618,21 @@ class ProfileScreen(Screens):
                 # adjust and append scar events to history
                 if the_cat.scar_event:
                     for x in range(len(the_cat.scar_event)):
-                        not_scarred = [' wounded ', ' injured ', ' battered ', ' hurt ', ' punished ']
                         the_cat.scar_event[x] = str(the_cat.scar_event[x]).replace(' is ', ' was ', 1)
                         the_cat.scar_event[x] = str(the_cat.scar_event[x]).replace(' loses ', ' lost ')
                         the_cat.scar_event[x] = str(the_cat.scar_event[x]).replace(' forces ', ' forced ')
+
+                        not_scarred = ['wounded', 'injured', 'battered', 'hurt', 'punished']
                         for y in not_scarred:
+                            the_cat.scar_event[x] = str(the_cat.scar_event[x]).replace(f' got {y} ', ' was scarred ')
                             the_cat.scar_event[x] = str(the_cat.scar_event[x]).replace(y, ' scarred ')
-                            the_cat.scar_event[x] = str(the_cat.scar_event[x]).replace(' got ', ' was ')
                             break
-                        if x == 1:
+                        if x == 0:
+                            the_cat.scar_event[x] = str(the_cat.scar_event[x]).replace(f'{the_cat.name} ', 'This cat ', 1)
+                        elif x == 1:
                             the_cat.scar_event[x] = str(the_cat.scar_event[x]).replace(f'{the_cat.name} was ', 'They were also ', 1)
                             the_cat.scar_event[x] = str(the_cat.scar_event[x]).replace(str(the_cat.name), 'They also', 1)
-                        if x >= 3:
+                        elif x >= 3:
                             the_cat.scar_event[x] = str(the_cat.scar_event[x]).replace(f'{the_cat.name} was ', 'Then they were ', 1)
                             the_cat.scar_event[x] = str(the_cat.scar_event[x]).replace(str(the_cat.name), 'Then they', 1)
                     scar_history = ' '.join(the_cat.scar_event)


### PR DESCRIPTION
More grammar adjustments for History tab.

I had missed a few things when trying to adjust how Reserved vs Abrasive was recorded in my previous PR, this actually fixes the problem and stops the game from crashing.