### PR TITLE
Reformat tests (with teyit)

### DIFF
--- a/tests/test_cat.py
+++ b/tests/test_cat.py
@@ -314,21 +314,21 @@ class TestMateFunctions(unittest.TestCase):
 
         # then
         # TODO: maybe not correct check
-        self.assertTrue(old_relation1.romantic_love < relation1.romantic_love)
-        self.assertTrue(old_relation1.platonic_like <= relation1.platonic_like)
-        self.assertTrue(old_relation1.dislike <= relation1.dislike)
-        self.assertTrue(old_relation1.comfortable < relation1.comfortable)
-        self.assertTrue(old_relation1.trust < relation1.trust)
-        self.assertTrue(old_relation1.admiration <= relation1.admiration)
-        self.assertTrue(old_relation1.jealousy <= relation1.jealousy)
+        self.assertLess(old_relation1.romantic_love, relation1.romantic_love)
+        self.assertLessEqual(old_relation1.platonic_like, relation1.platonic_like)
+        self.assertLessEqual(old_relation1.dislike, relation1.dislike)
+        self.assertLess(old_relation1.comfortable, relation1.comfortable)
+        self.assertLess(old_relation1.trust, relation1.trust)
+        self.assertLessEqual(old_relation1.admiration, relation1.admiration)
+        self.assertLessEqual(old_relation1.jealousy, relation1.jealousy)
 
-        self.assertTrue(old_relation2.romantic_love < relation2.romantic_love)
-        self.assertTrue(old_relation2.platonic_like <= relation2.platonic_like)
-        self.assertTrue(old_relation2.dislike <= relation2.dislike)
-        self.assertTrue(old_relation2.comfortable < relation2.comfortable)
-        self.assertTrue(old_relation2.trust < relation2.trust)
-        self.assertTrue(old_relation2.admiration <= relation2.admiration)
-        self.assertTrue(old_relation2.jealousy <= relation2.jealousy)
+        self.assertLess(old_relation2.romantic_love, relation2.romantic_love)
+        self.assertLessEqual(old_relation2.platonic_like, relation2.platonic_like)
+        self.assertLessEqual(old_relation2.dislike, relation2.dislike)
+        self.assertLess(old_relation2.comfortable, relation2.comfortable)
+        self.assertLess(old_relation2.trust, relation2.trust)
+        self.assertLessEqual(old_relation2.admiration, relation2.admiration)
+        self.assertLessEqual(old_relation2.jealousy, relation2.jealousy)
 
     def test_unset_mate_relationship(self):
         # given
@@ -349,21 +349,21 @@ class TestMateFunctions(unittest.TestCase):
 
         # then
         # TODO: maybe not correct check
-        self.assertTrue(old_relation1.romantic_love > relation1.romantic_love)
-        self.assertTrue(old_relation1.platonic_like >= relation1.platonic_like)
-        self.assertTrue(old_relation1.dislike >= relation1.dislike)
-        self.assertTrue(old_relation1.comfortable > relation1.comfortable)
-        self.assertTrue(old_relation1.trust > relation1.trust)
-        self.assertTrue(old_relation1.admiration >= relation1.admiration)
-        self.assertTrue(old_relation1.jealousy >= relation1.jealousy)
+        self.assertGreater(old_relation1.romantic_love, relation1.romantic_love)
+        self.assertGreaterEqual(old_relation1.platonic_like, relation1.platonic_like)
+        self.assertGreaterEqual(old_relation1.dislike, relation1.dislike)
+        self.assertGreater(old_relation1.comfortable, relation1.comfortable)
+        self.assertGreater(old_relation1.trust, relation1.trust)
+        self.assertGreaterEqual(old_relation1.admiration, relation1.admiration)
+        self.assertGreaterEqual(old_relation1.jealousy, relation1.jealousy)
 
-        self.assertTrue(old_relation2.romantic_love > relation2.romantic_love)
-        self.assertTrue(old_relation2.platonic_like >= relation2.platonic_like)
-        self.assertTrue(old_relation2.dislike >= relation2.dislike)
-        self.assertTrue(old_relation2.comfortable > relation2.comfortable)
-        self.assertTrue(old_relation2.trust > relation2.trust)
-        self.assertTrue(old_relation2.admiration >= relation2.admiration)
-        self.assertTrue(old_relation2.jealousy >= relation2.jealousy)
+        self.assertGreater(old_relation2.romantic_love, relation2.romantic_love)
+        self.assertGreaterEqual(old_relation2.platonic_like, relation2.platonic_like)
+        self.assertGreaterEqual(old_relation2.dislike, relation2.dislike)
+        self.assertGreater(old_relation2.comfortable, relation2.comfortable)
+        self.assertGreater(old_relation2.trust, relation2.trust)
+        self.assertGreaterEqual(old_relation2.admiration, relation2.admiration)
+        self.assertGreaterEqual(old_relation2.jealousy, relation2.jealousy)
 
 class TestStatusChange(unittest.TestCase):
 
@@ -377,11 +377,11 @@ class TestStatusChange(unittest.TestCase):
         apprentice.mentor = mentor
 
         # when
-        self.assertTrue(apprentice.mentor != None)
+        self.assertNotEqual(apprentice.mentor, None)
         apprentice.status_change("warrior")
         
         # then
-        self.assertTrue(apprentice.skill != "???")
-        self.assertTrue(apprentice.skill in apprentice.skills)
-        self.assertTrue(apprentice.mentor == None)
+        self.assertNotEqual(apprentice.skill, "???")
+        self.assertIn(apprentice.skill, apprentice.skills)
+        self.assertEqual(apprentice.mentor, None)
         self.assertFalse(mentor.apprentice)

--- a/tests/test_relation_events.py
+++ b/tests/test_relation_events.py
@@ -154,7 +154,7 @@ class Pregnancy(unittest.TestCase):
         relation_events.handle_zero_moon_pregnant(cat,None,None,clan)
 
         # then
-        self.assertTrue(cat.ID in clan.pregnancy_data.keys())
+        self.assertIn(cat.ID, clan.pregnancy_data.keys())
 
     @patch('scripts.cat_relations.relation_events.Relation_Events.get_kits_chance')
     def test_pair(self, get_kits_chance):
@@ -172,7 +172,7 @@ class Pregnancy(unittest.TestCase):
         relation_events.handle_zero_moon_pregnant(cat1,cat2,relation,clan)
 
         # then
-        self.assertTrue(cat1.ID in clan.pregnancy_data.keys())
+        self.assertIn(cat1.ID, clan.pregnancy_data.keys())
         self.assertEqual(clan.pregnancy_data[cat1.ID]["second_parent"], cat2.ID)
 
     @patch('scripts.cat_relations.relation_events.Relation_Events.get_kits_chance')
@@ -215,4 +215,4 @@ class Pregnancy(unittest.TestCase):
         relation_events.handle_having_kits(cat=cat1,clan=test_clan)
 
         # then
-        self.assertFalse(cat1.ID in test_clan.pregnancy_data.keys())
+        self.assertNotIn(cat1.ID, test_clan.pregnancy_data.keys())


### PR DESCRIPTION
Ran the tests through teyit since the Python 3.12 changelog recommends it, apparently it's slated to remove some depreciated unittest features. Don't think any of those were present here though, so this is mostly just convention stuff.

```
assertTrue               => assertEqual               refactoring happened 1 times.
assertFalse              => assertNotIn               refactoring happened 1 times.
assertTrue               => assertNotEqual            refactoring happened 2 times.
assertTrue               => assertIn                  refactoring happened 3 times.
assertTrue               => assertLess                refactoring happened 6 times.
assertTrue               => assertGreater             refactoring happened 6 times.
assertTrue               => assertLessEqual           refactoring happened 8 times.
assertTrue               => assertGreaterEqual        refactoring happened 8 times.
```

(``apprentice.skill != "???"`` failing is unrelated to the reformat, it also fails in experimental)