### PR TITLE
Revert MacOS build to Python 3.10 & pygame 2.1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,17 +155,17 @@ jobs:
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Python 3.11 x64
+      - name: Setup Python 3.10 x64
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.10'
           architecture: 'x64'
       - name: Update pip
         run: python -m pip install --upgrade pip
       - name: Update setuptools and wheel
         run: python -m pip install --upgrade setuptools wheel
       - name: Install dependencies
-        run: python -m pip install -r requirements.txt
+        run: python -m pip install pygame==2.1.2 ujson
       - name: Install Pillow for icon format conversion
         run: python -m pip install --upgrade Pillow
       - name: Install PyInstaller


### PR DESCRIPTION
Seems like the macOS build doesn't work with Python 3.11 + pygame 2.1.3. Few ppl in on the discord had this issue and it doesn't run for me on a vm either, not sure why exactly. Probably best to just roll it back for now.