### PR TITLE
Minor fixes for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
         run: python -m PyInstaller Clangen.spec
       - uses: actions/upload-artifact@v3
         with:
-          name: Clangen_Win32.zip
+          name: Clangen_Win32
           path: dist/
       - name: Create archive for release (.zip)
         if: startsWith(github.ref, 'refs/tags/')
@@ -101,7 +101,7 @@ jobs:
         run: python -m PyInstaller Clangen.spec
       - uses: actions/upload-artifact@v3
         with:
-          name: Clangen_Win64.zip
+          name: Clangen_Win64
           path: dist/
       - name: Create archive for release (.zip)
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,12 +59,13 @@ jobs:
       - name: Run PyInstaller
         #run: python -m PyInstaller -i resources/images/icon.png --name clangen --windowed --noupx --onedir --clean --add-data "sprites;sprites" --add-data "resources;resources" --add-data "README.md;." main.py
         run: python -m PyInstaller Clangen.spec
-      - name: Create archive (.zip)
-        run: tar.exe -a -c -f Clangen_Win32.zip -C dist Clangen
       - uses: actions/upload-artifact@v3
         with:
           name: Clangen_Win32.zip
           path: dist/
+      - name: Create archive for release (.zip)
+        if: startsWith(github.ref, 'refs/tags/')
+        run: tar.exe -a -c -f Clangen_Win32.zip -C dist Clangen
       - name: Release 
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -98,12 +99,13 @@ jobs:
       - name: Run PyInstaller
         #run: python -m PyInstaller -i resources/images/icon.png --name clangen --windowed --noupx --onedir --clean --add-data "sprites;sprites" --add-data "resources;resources" --add-data "README.md;." main.py
         run: python -m PyInstaller Clangen.spec
-      - name: Create archive (.zip)
-        run: tar.exe -a -c -f Clangen_Win64.zip -C dist Clangen
       - uses: actions/upload-artifact@v3
         with:
           name: Clangen_Win64.zip
           path: dist/
+      - name: Create archive for release (.zip)
+        if: startsWith(github.ref, 'refs/tags/')
+        run: tar.exe -a -c -f Clangen_Win64.zip -C dist Clangen
       - name: Release 
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -137,12 +139,13 @@ jobs:
       - name: Run PyInstaller
         #run: python -m PyInstaller -i resources/images/icon.png --name clangen --windowed --noupx --onedir --clean --add-data "sprites;sprites" --add-data "resources;resources" --add-data "README.md;." main.py
         run: python -m PyInstaller Clangen.spec
-      - name: Create archive (.zip)
-        run: tar.exe -a -c -f Clangen_Win64.zip -C dist Clangen
       - uses: actions/upload-artifact@v3
         with:
           name: Clangen_Win64_Windows10+
           path: dist/
+      - name: Create archive for release (.zip)
+        if: startsWith(github.ref, 'refs/tags/')
+        run: tar.exe -a -c -f Clangen_Win64_Windows10+.zip -C dist Clangen
       - name: Release 
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
- Fixes win10+ zip not being included in releases because it had the wrong name
- Makes the tar.exe release zip only build when a tag is pushed
- Fixes the extension for the win32/64 artifacts being .zip.zip